### PR TITLE
Parse lib

### DIFF
--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -88,7 +88,7 @@ module.exports = {
   },
 
   _parseFolder: function(basePath, options) {
-    let addon = 'ember-l10n';
+    let addon = '"ember-l10n"';
 
     let modules = fs.readdirSync(basePath);
     modules.forEach(module => {

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -83,10 +83,14 @@ module.exports = {
   },
 
   parseAddons: function(options) {
-    let addon = 'ember-l10n';
-    let basePath = 'node_modules';
-    let modules = fs.readdirSync(basePath);
+    this._parseFolder('node_modules', options);
+    this._parseFolder('lib', options);
+  },
 
+  _parseFolder: function(basePath, options) {
+    let addon = 'ember-l10n';
+
+    let modules = fs.readdirSync(basePath);
     modules.forEach(module => {
       if (module===addon) {
         return;


### PR DESCRIPTION
This PR fixes two things:

* It also parses packages in the /lib folder, e.g. in-repo-addons/engines
* It ignores packages that only contain a reference to ember-l10n. This can happen if you install ember-l10n via a symlink or similar, then for example the chalk package has this in its package.json:

```js
"_requiredBy": [
    "/babel-core",
    "/ember-l10n",
    "/inquirer"
  ],
```

Which resulted in it being parsed, too. Now, only `"ember-l10n"` is checked, which solved this issue.