### PR TITLE
Fingerprint locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ and replaced at runtime.
 ember-l10n provides powerful string substitution and even component
 substitution for dynamic strings. See the Components section below.
 
+## Note for Upgrading
+
+The latest version has introduced fingerprinting for the generated JSON files. Please read the [Fingerprinting](#fingerprinting) & [Converter](#converter) sections.
 
 ## Ember Side
 
@@ -76,17 +79,24 @@ When installing via `ember install ember-l10n`, an `l10n` service will be create
 There, you can configure (and overwrite) all service properties/methods:
 
 ```js
-import Ember from 'ember';
+import computed from 'ember-computed';
 import L10n from 'ember-l10n/services/l10n';
+import l10nFingerprintMap from './../utils/l10n-fingerprint-map';
 
 export default L10n.extend({
-  availableLocales: Ember.computed(function() {
+
+  availableLocales: computed(function() {
     return {
       'en': this.t('en')
     };
   }),
+
   autoInitialize: true,
-  jsonPath: '/assets/locales'
+
+  jsonPath: '/assets/locales',
+
+  // Make this return null if you do not want to use fingerprinting
+  fingerprintMap: l10nFingerprintMap
 });
 ```
 
@@ -111,6 +121,14 @@ export default {
   name: 'my-l10n-initializer'
 };
 ```
+
+### Fingerprinting
+
+By default, it is assumed that the locale files are fingerprinted. This makes it possible to aggressively cache them. For this, the default blueprint will generate a file `app/utils/l10n-fingerprint-map.js`. (If you upgraded recently, run `ember g ember-l10n` to create the file).
+
+Whenever you convert a .po file to JSON with `ember l10n:convert`, it will then by default put the created JSON in a fingerprinted subfolder, and update the `l10n-fingerprint-map.js` file with the new fingerprint. This map is then in turn used by the `l10n` service. Note that this means that every language file is fingerprinted separately.
+
+If you do not wish to use fingerprinting, make the `fingerprintMap` property on the service return `null`. Also, you need to deactivate it when converting the .po file: `ember l10n:convert -fingerprint-map=false`.
 
 ### Helpers
 
@@ -289,6 +307,8 @@ ember l10n:convert <options...>
   --gettextjs-path (String) (Default: './node_modules/gettext.js/bin/po2json') The path where gettext.js is available
 ```
 
+Note that by default, this will create a fingerprinted json file & update the `app/utils/l10n-fingerprint-map.js` accordingly. If you do not wish to use fingerprinting, use  `--fingerprint-map=false`.
+
 ### Synchronizer
 
 The synchronizer will parse a given `PO` file, use the message ids from each entry and uses them as new message ids accross `JS` and `HBS` files in your app. This is especially helpful if you proof read your current message ids before handing them over to translators for other languages.
@@ -344,7 +364,7 @@ This library follows [Semantic Versioning](http://semver.org)
 
 ## Legal
 
-[Cropster](https://cropster.com), GmbH &copy; 2016
+[Cropster](https://cropster.com), GmbH &copy; 2017
 
 [@cropster](http://twitter.com/cropster)
 

--- a/README.md
+++ b/README.md
@@ -302,6 +302,8 @@ ember l10n:convert <options...>
     aliases: -i <value>
   --convert-to (String) (Default: './public/assets/locales') Directory to write JSON files to
     aliases: -o <value>
+  --fingerprint-map (String) (Default: ./app/utils/l10n-fingerprint-map.js) Path to the fingerprint-map file. Set to false to deactivate fingerprinting.
+    aliases: -f <value>
   --language (String) (Default: 'en') Target language for PO to JSON conversion
     aliases: -l <value>
   --gettextjs-path (String) (Default: './node_modules/gettext.js/bin/po2json') The path where gettext.js is available

--- a/app/utils/fingerprint-map.js
+++ b/app/utils/fingerprint-map.js
@@ -1,0 +1,3 @@
+export default {
+  en: 'default'
+};

--- a/blueprints/ember-l10n/files/__root__/services/l10n.js
+++ b/blueprints/ember-l10n/files/__root__/services/l10n.js
@@ -1,12 +1,19 @@
-import Ember from 'ember';
+import computed from 'ember-computed';
 import L10n from 'ember-l10n/services/l10n';
+import l10nFingerprintMap from './../utils/l10n-fingerprint-map';
 
 export default L10n.extend({
-  availableLocales: Ember.computed(function() {
+
+  availableLocales: computed(function() {
     return {
       'en': this.t('en')
     };
   }),
+
   autoInitialize: true,
-  jsonPath: '/assets/locales'
+
+  jsonPath: '/assets/locales',
+
+  // Make this return null if you do not want to use fingerprinting
+  fingerprintMap: l10nFingerprintMap
 });

--- a/blueprints/ember-l10n/files/__root__/utils/l10n-fingerprint-map.js
+++ b/blueprints/ember-l10n/files/__root__/utils/l10n-fingerprint-map.js
@@ -1,0 +1,3 @@
+export default {
+  "en": "default"
+};

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -33,15 +33,29 @@ module.exports = {
   },
 
   start: function(options) {
+    let fingerprint = +(new Date());
+
+    let shouldFingerprint = true;
+    switch (options.fingerprintMap) {
+      case 'null':
+      case 'false':
+      case '':
+        shouldFingerprint = false;
+    }
+    if (!options.fingerprintMap) {
+      shouldFingerprint = false;
+    }
+    let fullPath = shouldFingerprint ? `${options.convertTo}/${fingerprint}` : options.convertTo;
+
     let poFile = `${options.convertFrom}/${options.language}.po`;
-    let jsonFile = `${options.convertTo}/${options.language}.json`;
+    let jsonFile = `${fullPath}/${options.language}.json`;
 
     if (!fileExists(poFile)) {
       this.ui.writeLine(chalk.red.bold(`PO file ${poFile} does not exist!`));
       return;
     }
 
-    shell.mkdir('-p', options.convertTo);
+    shell.mkdir('-p', fullPath);
     shell.exec(`touch ${jsonFile}`);
 
     this.ui.writeLine(
@@ -54,6 +68,8 @@ CREATING JSON FILE
 
     let args = [poFile, jsonFile, `-p`].join(' ');
     shell.exec(`node ${options.gettextjsPath} ${args}`);
+
+    this.updateFingerprintMap(fingerprint, options);
 
     this.ui.writeLine(chalk.green.bold(`\nFINISHED ✔`));
   },
@@ -128,12 +144,38 @@ CREATING JSON FILE
       // the options are not coming from the CLI arg string
       nopt.clean(options, optionTypeMap);
 
-
       this._parsedConfig = {
         options: options
       };
     }
 
     return this._parsedConfig;
+  },
+
+  updateFingerprintMap(fingerprint, options) {
+    let locale = options.language;
+    let fileName = options.fingerprintMap;
+
+    if (!fileName) {
+      return;
+    }
+
+    let fileContent = fs.readFileSync(fileName, 'utf8');
+
+    try {
+      fileContent = fileContent.trim();
+      fileContent = fileContent.substring(fileContent.indexOf('{'), fileContent.length - 1);
+
+      let json = JSON.parse(fileContent);
+      json[locale] = `${fingerprint}`;
+
+      let newFileContent = `export default ${JSON.stringify(json, null, 2)};`;
+      fs.writeFileSync(fileName, newFileContent);
+    } catch (e) {
+      this.ui.writeLine(chalk.red.bold(`\nCould not update ${fileName}`));
+      this.ui.writeLine(chalk.red.bold(e));
+    }
+
+    this.ui.writeLine(`Updated fingerprint-map at ${fileName}`);
   }
 };

--- a/lib/utils/convert-options.js
+++ b/lib/utils/convert-options.js
@@ -21,6 +21,14 @@ module.exports = [
     validInConfig: true
   },
   {
+    name: 'fingerprint-map',
+    type: String,
+    aliases: ['f'],
+    default: './app/utils/l10n-fingerprint-map.js',
+    description: 'Path to the fingerprint-map file',
+    validInConfig: true
+  },
+  {
     name: 'language',
     type: String,
     aliases: ['l'],

--- a/lib/utils/convert-options.js
+++ b/lib/utils/convert-options.js
@@ -25,7 +25,7 @@ module.exports = [
     type: String,
     aliases: ['f'],
     default: './app/utils/l10n-fingerprint-map.js',
-    description: 'Path to the fingerprint-map file',
+    description: 'Path to the fingerprint-map file. Set to false to deactivate fingerprinting',
     validInConfig: true
   },
   {


### PR DESCRIPTION
This PR changes the default behavior of `ember l10n:convert` to create a fingerprinted locale file.
The fingerprint is saved in the `app/utils/l10n-fingerprint-map.js` file, which is then retrieved from the `l10n` service.

Steps to upgrade to the new behavior:

1.) Upgrade `ember-l10n`
2.) Run `ember g ember-l10n` to generate the base `l10n-fingerprint-map.js` file, and make sure to also include the changes from the `app/services/l10n.js` file where the fingerprint map is loaded
3.) Re-run `ember l10n:convert` for all your locales to create the fingerprinted versions