### PR TITLE
Validate translations when running convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,14 +404,21 @@ To see all available command line options for the converter script please run:
 ```
 ember l10n:convert <options...>
   Convert PO files to JSON
-  --convert-from (String) (Default: './translations') Directory of PO file to convert
-    aliases: -i <value>
-  --convert-to (String) (Default: './public/assets/locales') Directory to write JSON files to
-    aliases: -o <value>
-    aliases: -f <value>
-  --language (String) (Default: 'en') Target language for PO to JSON conversion
-    aliases: -l <value>
+    --convert-from (String) (Default: ./translations) Directory of PO file to convert
+      aliases: -i <value>
+    --convert-to (String) (Default: ./public/assets/locales) Directory to write JSON files to
+      aliases: -o <value>
+    --language (String) (Default: en) Target language for PO to JSON conversion
+      aliases: -l <value>
+    --validate-throw (String) (Default: null) For which validation level the script should abort. Can be: ERROR, WARNING, null
+      aliases: -vt <value>
+    --dry-run (Boolean) (Default: false) If true, only generate but do not actually write to a file
+      aliases: -dr
+
 ```
+
+Note that this will also validate the generated JSON file for common syntax errors. 
+For example, it will check if e.g. `This is {{description}}` is wrongly translated to `Das ist die {{Beschreibung}}`. It will print out any found issues to the console. Alternatively, you can specify `validate-throw=ERROR` to force the script to abort if an error is found. 
 
 ### Synchronizer
 

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -67,6 +67,20 @@ module.exports = Object.assign(BaseCommand, {
       aliases: ['l'],
       default: 'en',
       description: 'Target language for PO to JSON conversion'
+    },
+    {
+      name: 'validate-throw',
+      type: String,
+      aliases: ['vt'],
+      default: null,
+      description: 'For which validation level the script should abort. Can be: ERROR, WARNING, null'
+    },
+    {
+      name: 'dry-run',
+      type: Boolean,
+      aliases: ['dr'],
+      default: false,
+      description: 'If true, only generate but do not actually write to a file'
     }
   ],
 
@@ -103,10 +117,247 @@ CREATING JSON FILE
 
     let poData = fs.readFileSync(poFile);
     let jsonData = parser.po.parse(poData);
-    jsonData = JSON.stringify(jsonData, null, 2);
 
-    fs.writeFileSync(jsonFile, jsonData, 'utf8');
+    let validationErrors = this.validate(jsonData);
+    this._printValidationErrors(validationErrors);
+
+    if (this._shouldThrowForValidation(validationErrors, options.validateThrow)) {
+      throw new Error('Validation of JSON was not successfully, aborting...');
+    }
+
+    if (!options.dryRun) {
+      let strData = JSON.stringify(jsonData, null, 2);
+      fs.writeFileSync(jsonFile, strData, 'utf8');
+    }
 
     this.ui.writeLine(chalk.green.bold(`\nFINISHED ✔`));
+  },
+
+  /**
+   * Validate a given JSON object for correct syntax.
+   * This returns an array of error objects.
+   *
+   * @method validate
+   * @param {Object} json
+   * @return {Object[]}
+   * @protected
+   */
+  _validationErrors: [],
+  validate(json) {
+    let { translations } = json;
+    this._validationErrors = [];
+
+    Object.keys(translations).forEach((namespace) => {
+      Object.keys(translations[namespace]).forEach((k) => {
+        this._validateItem(translations[namespace][k]);
+      });
+    });
+
+    return this._validationErrors;
+  },
+
+  /**
+   * Validate one translation item.
+   * This mutates this._validationErrors.
+   *
+   * @method _validateItem
+   * @param {Object }item
+   * @private
+   */
+  _validateItem(item) {
+    let { msgid: id, msgid_plural: idPlural, msgstr: translations } = item;
+
+    this._validatePlaceholders({ id, idPlural, translations });
+    this._validateTranslatedPlaceholders({ id, translations });
+  },
+
+  /**
+   * Validate the regular placeholders of an item.
+   * This possibly modifies this._validationErrors.
+   *
+   * @method _validatePlaceholder
+   * @param {String} id
+   * @param {String} idPlural
+   * @param {String[]} translations
+   * @private
+   */
+  _validatePlaceholders({ id, idPlural, translations }) {
+    // search for {{placeholderName}}
+    // Also search for e.g. Chinese symbols in the placeholderName
+    let pattern = /{{\s*(\S+?)\s*?}}/g;
+    let placeholders = id.match(pattern) || [];
+
+    // We also want to add placeholders from the plural string
+    if (idPlural) {
+      let pluralPlaceholders = idPlural.match(pattern) || [];
+      pluralPlaceholders.forEach((placeholder) => {
+        if (!placeholders.includes(placeholder)) {
+          placeholders.push(placeholder);
+        }
+      });
+    }
+
+    if (!placeholders.length) {
+      return;
+    }
+
+    translations.forEach((translation) => {
+      let translatedPlaceholders = translation.match(pattern) || [];
+
+      // Search for placeholders in the translated string that are not in the original string
+      let invalidPlaceholder = translatedPlaceholders.find((placeholder) => !placeholders.includes(placeholder));
+      if (invalidPlaceholder) {
+        this._validationErrors.push({
+          id,
+          translation,
+          message: `The placeholder "${invalidPlaceholder}" seems to be wrongly translated. Allowed: ${placeholders.join(', ')}`,
+          level: 'ERROR'
+        });
+      }
+    });
+  },
+
+  /**
+   * Validate the translated (complex) placeholders of an item.
+   * This mutates this._validationErrors.
+   *
+   * @method _validateTranslatedPlaceholders
+   * @param {String} id
+   * @param {String[]} translations
+   * @private
+   */
+  _validateTranslatedPlaceholders({ id, translations }) {
+    // find all: {{placeholder 'also translated'}}
+    // {{placeholder "also translated"}}
+    // {{placeholder \'also translated\'}}
+    // {{placeholder \"also translated\"}}
+    let pattern = /{{\s*([\w]+)\s+((\\')|(\\")|"|')(.*?)((\\')|(\\")|"|')\s*}}/g;
+
+    // This only works in non-plural form, so we assume only one translation
+    let [translation] = translations;
+
+    // Build an object describing the complex placeholders from the original string
+    let placeholders = id.match(pattern) || [];
+    if (!placeholders.length) {
+      return;
+    }
+    let placeholderConfig = placeholders.map((str) => {
+      pattern.lastIndex = 0;
+      let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
+      return {
+        fullResult,
+        placeholder,
+        quoteSymbol1,
+        quoteSymbol2,
+        content
+      };
+    });
+
+    // Build an object describing the complex placeholders from the translated string
+    let translatedPlaceholders = translation.match(pattern) || [];
+    let translatedPlaceholderConfig = translatedPlaceholders.map((str) => {
+      pattern.lastIndex = 0;
+      let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
+      return {
+        fullResult,
+        placeholder,
+        quoteSymbol1,
+        quoteSymbol2,
+        content
+      };
+    });
+
+    placeholderConfig.forEach(({ placeholder, content }) => {
+      // First we check for missing/invalid placeholders
+      // This can happen e.g. if a translator changes {{placeholder 'test'}} to {{placeholder `test`}}
+      // So we make sure that all originally defined placeholders actually still exist
+      if (!translatedPlaceholderConfig.find((config) => config.placeholder === placeholder)) {
+        this._validationErrors.push({
+          id,
+          translation,
+          message: `The complex placeholder "${placeholder}" is not correctly translated`,
+          level: 'ERROR'
+        });
+        return;
+      }
+
+      // Then, we check if the placeholder content is correctly translated
+      // If the whole string is not translated at all, we ignore it
+      // Only if the string is translated but the placeholder part not will this show a warning
+      // NOTE: This is just a warning (not an error), as it is theoretically possible this is done on purpose
+      // E.g. a word _might_ be the same in translated form
+      if (id === translation) {
+        return;
+      }
+      let invalidTranslatedPlaceholder = translatedPlaceholderConfig.find((config) => {
+        return config.content === content;
+      });
+
+      if (invalidTranslatedPlaceholder) {
+        this._validationErrors.push({
+          id,
+          translation,
+          message: `The content "${content}" for complex placeholder "${placeholder}" is not translated`,
+          level: 'WARNING'
+        });
+      }
+    });
+  },
+
+  /**
+   * If an error should be thrown for the given list of errors & the specified min. level of errors.
+   *
+   * @method _shouldThrowForValidation
+   * @param {Object[]} errors
+   * @param {null|ERROR|WARNING} minLevel
+   * @return {Boolean}
+   * @private
+   */
+  _shouldThrowForValidation(errors, minLevel) {
+    if (!minLevel) {
+      return false;
+    }
+
+    if (minLevel.toUpperCase() === 'ERROR') {
+      return !!errors.findBy('level', 'ERROR');
+    }
+
+    if (minLevel.toUpperCase() === 'WARNING') {
+      return errors.length > 0;
+    }
+
+    throw new Error(`Invalid value for ${minLevel} "validateThrow", only ERROR, WARNING, and null are allowed.`);
+  },
+
+  /**
+   * Print a list of validation errors.
+   *
+   * @method _printValidationErrors
+   * @param {Object[]} errors
+   * @private
+   */
+  _printValidationErrors(errors) {
+    errors.forEach((error) => {
+      this._printValidationError(error);
+    });
+  },
+
+  /** Print one validation errors.
+   *
+   * @method _printValidationError
+   * @param {Object} error
+   * @private
+   */
+  _printValidationError({ id, translation, message, level }) {
+    level = level.toUpperCase();
+    let color = level === 'ERROR' ? 'red' : 'yellow';
+    let label = level === 'ERROR'
+      ? 'Validation error'
+      : 'Validation warning';
+
+    this.ui.writeLine(chalk[color].bold(`${label} for "${id}":`));
+    this.ui.writeLine(chalk[color].bold(`   Translation: "${translation}"`));
+    this.ui.writeLine(chalk[color].bold(`   Problem: ${message}`));
   }
+
 });


### PR DESCRIPTION
When running `ember l10n:convert`, it will validate the generated JSON for syntax issues.

This resolves #38 .

This is a non-breaking change. It introduces two new arguments for the `ember l10n:convert` command:

* `--dry-run` (by default false): If true, only generate it but do not generate/save a file. Can be used to e.g. test validation without accidentally overwriting files.
* `--validate-throw` (by default null): Set to ERROR or WARNING to force the conversion to stop if an error or a warning occur.

This is an example output you might get:

![image](https://user-images.githubusercontent.com/2411343/43898560-7b845c34-9bdf-11e8-9650-58a14923d5ea.png)
