### PR TITLE
Add node tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,25 @@ module.exports = {
       })
     },
 
+    // node tests
+    {
+      files: [
+        'node-tests/**/*.js'
+      ],
+      parserOptions: {
+        sourceType: 'script',
+        ecmaVersion: 2017
+      },
+      env: {
+        browser: false,
+        node: true
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+      })
+    },
+
     // test files
     {
       files: ['tests/**/*.js'],

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty
@@ -43,6 +43,7 @@ install:
 
 script:
   - yarn lint:js
+  - yarn node-tests
   # Usually, it's ok to finish the test scenario without reverting
   #  to the addon's original dependency state, skipping "cleanup".
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/lib/commands/abstract.js
+++ b/lib/commands/abstract.js
@@ -106,10 +106,8 @@ module.exports = {
    * @return {Promise}
    */
   run(options) {
-    let promise = this.checkDependencies_();
-    promise.then(() => this.start(options));
-
-    return promise;
+    return this.checkDependencies_()
+      .then(() => this.start(options));
   },
 
   /**

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -183,6 +183,7 @@ module.exports = Object.assign(BaseCommand, {
    * @return {Void}
    */
   start(options) {
+    let startTime = +(new Date);
     // make the temporary folder first
     this._preCommand(options);
 
@@ -214,6 +215,10 @@ module.exports = Object.assign(BaseCommand, {
 
     // cleanup temporary folder
     this._postCommand(options);
+
+    let endTime = +(new Date);
+    let duration = endTime - startTime;
+    this.ui.writeLine(chalk.green.bold(`Time to complete: ${(duration / 1000).toFixed(2)} seconds`));
   },
 
   /**

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -7,6 +7,7 @@ let shell = require('shelljs');
 let AbstractCommand = require('./abstract');
 let BaseCommand = Object.create(AbstractCommand);
 let path = require('path');
+let fs = require('fs');
 
 // enable error reporting
 shell.config.fatal = true;
@@ -443,13 +444,22 @@ EXTRACTING TEMPLATE TRANSLATIONS
       let xgettextTemplatePath = path.dirname(require.resolve('xgettext-template'));
       let parser = `node ${path.join(xgettextTemplatePath, 'bin', 'xgettext-template')}`;
 
+      let tmpHBSFile = file.replace(/\.hbs$/, '.l10n.hbs');
       let tmpPOTFile = file.replace(/\.hbs$/, '.l10n.pot');
 
       // create temporary files directly in folder in order
       // to provide correct path information message comments
       this.tryInvoke_(() => {
         shell.touch(tmpPOTFile);
+        shell.touch(tmpHBSFile);
       });
+
+      // clean up whitespace for the parser
+      let data = fs.readFileSync(file, encoding);
+      let parsedData = data
+        .replace(/(\n|(\r\n))[\t ]*/gm, '\n') // Remove leading whitespace after line breaks
+        .replace(/[\t ]+/gm, ' '); // Remove duplicate spaces/tabs
+      fs.writeFileSync(tmpHBSFile, parsedData, encoding);
 
       // prepare correct output file depending on excludes
       let isExcluded = file.match(this.excludeRegex);
@@ -465,7 +475,7 @@ EXTRACTING TEMPLATE TRANSLATIONS
       // and write them to temporary POT file for merging
       let nodeOpts = opts.slice();
       nodeOpts.push(`--output ${tmpPOTFile}`);
-      let nodeArgs = `${nodeOpts.slice().join(' ')} ${file}`;
+      let nodeArgs = `${nodeOpts.slice().join(' ')} ${tmpHBSFile}`;
 
       this.tryInvoke_(() => {
         shell.exec(`${parser} ${nodeArgs}`);
@@ -491,7 +501,7 @@ EXTRACTING TEMPLATE TRANSLATIONS
 
       // cleanup temporary files from source
       this.tryInvoke_(() => {
-        shell.rm('-f', [tmpPOTFile]);
+        shell.rm('-f', [tmpPOTFile, tmpHBSFile]);
       });
     });
 

--- a/node-tests/acceptance/commands/extract-test.js
+++ b/node-tests/acceptance/commands/extract-test.js
@@ -1,0 +1,104 @@
+const { expect } = require('chai');
+const path = require('path');
+const fs = require('fs');
+const shell = require('shelljs');
+const rimraf = require('rimraf');
+const Command = require('ember-cli/lib/models/command');
+const MockUI = require('console-ui/mock');
+const ExtractCommand = require('./../../../lib/commands/extract');
+
+function getOptions(options = {}) {
+  return Object.assign({
+    defaultLanguage: 'en',
+    bugAddress: 'test-email@email.com',
+    copyright: 'Test Company',
+    fromCode: 'UTF-8',
+    language: 'en',
+    package: 'Test App',
+    version: '1.0',
+    extractFrom: './tests/dummy/app',
+    excludePatterns: [],
+    skipPatterns: [],
+    skipDependencies: [],
+    skipAllDependencies: false,
+    generateOnly: false,
+    generateTo: null,
+    extractTo: './tmp/ember-l10n-tests',
+    keys: ['t', 'pt:1,2c', 'n:1,2', 'pn:1,2,4c'],
+    potName: 'messages.pot',
+    generateFrom: 'messages.pot'
+  }, options);
+}
+
+function getPoFileContent(filePath) {
+  // We want to ignore everything until the first comment
+  let fileContent = fs.readFileSync(filePath, 'UTF-8');
+  return fileContent.substr(fileContent.indexOf('#: '));
+}
+
+describe('extract command', function() {
+  let project;
+  let tmpDir = './tmp/ember-l10n-tests';
+
+  this.timeout(100000);
+
+  beforeEach(function() {
+    project = {
+      root: path.resolve('.'),
+      addonPackages: {},
+      hasDependencies() {
+        return true;
+      },
+      isEmberCLIProject() {
+        return true;
+      }
+    };
+
+    shell.mkdir('-p', tmpDir)
+  });
+
+  afterEach(function() {
+    rimraf.sync(tmpDir);
+  });
+
+  function createCommand(options = {}) {
+    Object.assign(options, {
+      ui: new MockUI(),
+      project: project,
+      environment: {},
+      settings: {}
+    });
+
+    let TestCommand = Command.extend(ExtractCommand);
+    return new TestCommand(options);
+  }
+
+  it('messages.po file is correctly generated from scratch', async function() {
+    let options = getOptions({});
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    let targetFileContent = getPoFileContent('./node-tests/fixtures/extract/default.pot');
+    let actualFileContent = getPoFileContent('./tmp/ember-l10n-tests/messages.pot');
+
+    expect(actualFileContent).to.equals(targetFileContent);
+  });
+
+  it('messages.po file is correctly updated if one already exists', async function() {
+    let options = getOptions({});
+
+    // First put a dummy existing messages.po in the output folder
+    fs.copyFileSync('./node-tests/fixtures/extract/base.pot', `${options.extractTo}/messages.pot`);
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    // We want to ignore everything until the first comment
+    let targetFileContent = getPoFileContent('./node-tests/fixtures/extract/default.pot');
+    let actualFileContent = getPoFileContent('./tmp/ember-l10n-tests/messages.pot');
+
+    expect(actualFileContent).to.equals(targetFileContent);
+  });
+
+});

--- a/node-tests/fixtures/extract/base.pot
+++ b/node-tests/fixtures/extract/base.pot
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Test Company
+# This file is distributed under the same license as the Test App package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Test App 1.0\n"
+"Report-Msgid-Bugs-To: test-email@email.com\n"
+"POT-Creation-Date: 2018-08-20 14:57+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tests/dummy/app/services/l10n.js:7
+msgid "en"
+msgstr ""
+
+#: tests/dummy/app/services/l10n.js:8
+msgid "de"
+msgstr ""
+
+#: tests/dummy/app/services/l10n.js:9
+msgid "ko"
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:24
+msgid "Hello world!"
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:39
+#: tests/dummy/app/templates/application.l10n.hbs:50
+msgid "You have {{count}} unit in your cart."
+msgid_plural "You have {{count}} units in your cart."
+msgstr[0] ""
+msgstr[1] ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:63
+msgid "My name is {{name}}."
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:89
+msgid "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:71
+msgctxt "menu"
+msgid "User"
+msgstr ""

--- a/node-tests/fixtures/extract/default.pot
+++ b/node-tests/fixtures/extract/default.pot
@@ -1,0 +1,71 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Test Company
+# This file is distributed under the same license as the Test App package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Test App 1.0\n"
+"Report-Msgid-Bugs-To: test-email@email.com\n"
+"POT-Creation-Date: 2018-08-20 14:57+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tests/dummy/app/services/l10n.js:7
+msgid "en"
+msgstr ""
+
+#: tests/dummy/app/services/l10n.js:8
+msgid "de"
+msgstr ""
+
+#: tests/dummy/app/services/l10n.js:9
+msgid "ko"
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:24
+msgid "Hello world!"
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:39
+#: tests/dummy/app/templates/application.l10n.hbs:50
+msgid "You have {{count}} unit in your cart."
+msgid_plural "You have {{count}} units in your cart."
+msgstr[0] ""
+msgstr[1] ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:63
+msgid "My name is {{name}}."
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:89
+msgid "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+msgstr ""
+
+#: tests/dummy/app/templates/application.l10n.hbs:71
+msgctxt "menu"
+msgid "User"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.l10n.hbs:2
+msgid "This page only contains text for tests"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.l10n.hbs:6
+msgid ""
+"Multi-line translations\n"
+"work!"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.l10n.hbs:13
+msgid ""
+"Translations with\n"
+"<strong>tags</strong> and weird indentation\n"
+"works"
+msgstr ""

--- a/node-tests/index.js
+++ b/node-tests/index.js
@@ -1,0 +1,21 @@
+const glob = require('glob');
+const Mocha = require('mocha');
+
+const mocha = new Mocha({
+  reporter: 'spec'
+});
+
+const arg = process.argv[2];
+const root = 'node-tests/';
+
+function addFiles(mocha, files) {
+  glob.sync(root + files).forEach(mocha.addFile.bind(mocha));
+}
+
+addFiles(mocha, '/**/*-test.js');
+
+mocha.run(function(failures) {
+  process.on('exit', function() {
+    process.exit(failures);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "ember build",
     "start": "ember serve",
     "test": "ember try:each",
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests"
+    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "node-tests": "node node-tests/index.js"
   },
   "repository": "https://github.com/Cropster/ember-l10n",
   "engines": {
@@ -20,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.7.0",
+    "chai": "^4.1.2",
     "ember-ajax": "^3.1.0",
     "ember-cli": "^3.3.0",
     "ember-cli-app-version": "^3.2.0",
@@ -47,8 +49,11 @@
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-node": "^7.0.1",
+    "glob": "^7.1.2",
     "loader.js": "^4.7.0",
-    "qunit-dom": "^0.7.1"
+    "mocha": "^5.2.0",
+    "qunit-dom": "^0.7.1",
+    "rimraf": "^2.6.2"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/templates/test-page.hbs
+++ b/tests/dummy/app/templates/test-page.hbs
@@ -1,0 +1,17 @@
+<h1>
+  {{t 'This page only contains text for tests'}}
+</h1>
+
+<p>
+  {{t
+    'Multi-line translations
+    work!'
+  }}
+</p>
+
+<p>
+  {{t 'Translations with
+          <strong>tags</strong> and weird indentation
+      works'
+  }}
+</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -1503,6 +1507,10 @@ broccoli-writer@~0.1.1:
     quick-temp "^0.1.0"
     rsvp "^3.0.6"
 
+browser-stdout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
+
 browserslist@^2.1.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.10.0.tgz#bac5ee1cc69ca9d96403ffb8a3abdc5b6aed6346"
@@ -1654,6 +1662,17 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
@@ -1699,6 +1718,10 @@ charm@^1.0.0:
   resolved "https://registry.yarnpkg.com/charm/-/charm-1.0.2.tgz#8add367153a6d9a581331052c4090991da995e35"
   dependencies:
     inherits "^2.0.1"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@1.7.0, chokidar@^1.6.0:
   version "1.7.0"
@@ -1882,6 +1905,10 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 commander@2.12.2, commander@^2.6.0:
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
+
+commander@2.15.1:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
 commander@2.8.x:
   version "2.8.1"
@@ -2095,7 +2122,7 @@ debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@~3.1.0:
+debug@3.1.0, debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2118,6 +2145,12 @@ decompress-response@^3.3.0:
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
   dependencies:
     mimic-response "^1.0.0"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -2200,6 +2233,10 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+diff@3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -2846,7 +2883,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -3524,6 +3561,10 @@ get-caller-file@^1.0.0, get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
@@ -3617,17 +3658,7 @@ glob-parent@^2.0.0:
     minimatch "^2.0.1"
     once "^1.3.0"
 
-glob@^5.0.10:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -3635,6 +3666,16 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     inflight "^1.0.4"
     inherits "2"
     minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^5.0.10:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -3714,6 +3755,10 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6,
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+
+growl@1.10.5:
+  version "1.10.5"
+  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3858,6 +3903,10 @@ hawk@3.1.3, hawk@~3.1.0, hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
+
+he@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
 heimdalljs-fs-monitor@^0.2.0:
   version "0.2.1"
@@ -5294,7 +5343,7 @@ minimatch@1:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5332,7 +5381,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
+mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -5341,6 +5390,22 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkd
 mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
+
+mocha@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
+  dependencies:
+    browser-stdout "1.3.1"
+    commander "2.15.1"
+    debug "3.1.0"
+    diff "3.5.0"
+    escape-string-regexp "1.0.5"
+    glob "7.1.2"
+    growl "1.10.5"
+    he "1.1.1"
+    minimatch "3.0.4"
+    mkdirp "0.5.1"
+    supports-color "5.4.0"
 
 moment-timezone@^0.3.0:
   version "0.3.1"
@@ -5997,6 +6062,10 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -7190,6 +7259,12 @@ sum-up@^1.0.1:
   dependencies:
     chalk "^1.0.0"
 
+supports-color@5.4.0, supports-color@^5.3.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
+  dependencies:
+    has-flag "^3.0.0"
+
 supports-color@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-0.2.0.tgz#d92de2694eb3f67323973d7ae3d8b55b4c22190a"
@@ -7203,12 +7278,6 @@ supports-color@^4.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
   dependencies:
     has-flag "^2.0.0"
-
-supports-color@^5.3.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
-  dependencies:
-    has-flag "^3.0.0"
 
 symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
   version "1.1.8"
@@ -7445,6 +7514,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 type-is@~1.6.15:
   version "1.6.15"


### PR DESCRIPTION
This PR:

* Adds a message showing the time needed to complete extraction (e.g. `Time to complete: 75.23 seconds`)
* Reintroduces whitespace cleaning in the .hbs files (While it works without it, there are some warnings and some inconsistent results depending on the OS)
  * Note that the whitespace cleaning works a bit different now: It will preserve line breaks, so that the line numbers in the po files are correct. 
  * It will only clean spaces/tabs
  * It also converts windows style line breaks (`\r\n` --> `\n`)
* Add basic tests for l10n:extract - as well as an infrastructure we can build upon for more tests - this was inspired by ember-cli-release's tests (fixing #37)