### PR TITLE
Improve detect locale

### DIFF
--- a/addon/services/l10n.js
+++ b/addon/services/l10n.js
@@ -334,7 +334,7 @@ export default Service.extend({
     }
 
     // otherwise return detected locale
-    if (forceLocale) {
+    if (!forceLocale) {
       this._log(`Automatically detected user language: "${locale}"`);
     } else {
       this._log(`Using forced locale: "${locale}"`);

--- a/addon/utils/guess-locale.js
+++ b/addon/utils/guess-locale.js
@@ -1,0 +1,91 @@
+import { A as array } from '@ember/array';
+
+/**
+ * Guess a locale based on allowed & desired locales.
+ * This will return the best-fitting locale.
+ *
+ * Given the following input:
+ * allowedLocales = ['en', 'de', 'zh_HK']
+ * desiredLocales = ['de-AT', 'de', 'en-US', 'en']
+ *
+ * It would by default return 'de'.
+ *
+ * If you specify `allowSubLocales=true`, it would instead return `de_AT`, the favorite sub-locale.
+ *
+ * In contrast, the following input:
+ * allowedLocales = ['en', 'de', 'zh_HK']
+ * desiredLocales = ['zh-CN', 'zh-HK', 'en-US', 'en']
+ *
+ * Would always return 'zh_HK', no matter if sub locales are allowed or not.
+ *
+ * @method guessLocale
+ * @param allowedLocales
+ * @param desiredLocales
+ * @param defaultLocale
+ * @param allowSubLocales
+ * @return {String}
+ */
+export function guessLocale(allowedLocales = [], desiredLocales = [], { defaultLocale = 'en', allowSubLocales = false } = {}) {
+  desiredLocales = desiredLocales || [defaultLocale];
+  desiredLocales = desiredLocales.map(normalizeLocale).map(getLocalAlias);
+
+  // Ensure everything is an Ember Array
+  if (!desiredLocales.find) {
+    desiredLocales = array(desiredLocales);
+  }
+  if (!allowedLocales.find) {
+    allowedLocales = array(allowedLocales);
+  }
+
+  let locale = desiredLocales.find((locale) => {
+    return allowedLocales.find((allowedLocale) => matchLocale(locale, allowedLocale));
+  }) || defaultLocale;
+
+  // If allowSubLocales=false, we do not want to return sub locales
+  // For example, if 'de' is allowed, but the first matching locale is de_AT, it will return 'de' if true, else de_AT.
+  if (allowSubLocales || allowedLocales.indexOf(locale) !== -1) {
+    return locale;
+  }
+
+  return allowedLocales.find((allowedLocale) => locale.indexOf(allowedLocale) === 0) || defaultLocale;
+}
+
+export function normalizeLocale(locale) {
+  locale = locale.replace('-', '_');
+  let [mainLocale, region] = locale.split('_');
+  if (region) {
+    return `${mainLocale}_${region.toUpperCase()}`;
+  }
+
+  return mainLocale;
+}
+
+export function getLocalAlias(locale) {
+  // There are variations of chinese locales
+  // We need to map those to either Simplified (CN) or Traditional (HK).
+  // Sadly, we cannot simply fall back to zh here, as that is not actually a valid locale
+  switch (locale) {
+    case 'zh_CN':
+    case 'zh_SG':
+    case 'zh_Hans':
+    case 'zh':
+      return 'zh_CN';
+    case 'zh_HK':
+    case 'zh_TW':
+    case 'zh_MO':
+    case 'zh_Hant':
+      return 'zh_HK';
+  }
+
+  return locale;
+}
+
+export function matchLocale(localeA, localeB) {
+  if (localeA === localeB) {
+    return true;
+  }
+
+  return localeA.indexOf(localeB) === 0;
+}
+
+export default guessLocale;

--- a/index.js
+++ b/index.js
@@ -3,11 +3,6 @@
 module.exports = {
   name: 'ember-l10n',
 
-  isDevelopingAddon: function() {
-    // @see: https://ember-cli.com/extending/#link-to-addon-while-developing
-    return false; // Set this to true for local development
-  },
-
   includedCommands: function() {
     return {
       'l10n:install': require('./lib/commands/install'),

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -268,8 +268,8 @@ module.exports = Object.assign(BaseCommand, {
     let potFile = `${options.extractTo}/${options.generateFrom}`;
     let poFile = options.generateTo;
 
-    this.initPOFile(options, potFile, poFile);
-    this.postCommand(options);
+    this._initPOFile(options, potFile, poFile);
+    this._postCommand(options);
 
     return true;
   },

--- a/tests/unit/services/l10n-test.js
+++ b/tests/unit/services/l10n-test.js
@@ -35,7 +35,7 @@ module('Unit | Service | l10n', function(hooks) {
                   'msgstr': [
                     'You have {{count}} unit in your cart.',
                     'You have {{count}} units in your cart.'
-                  ],
+                  ]
                 },
                 'STATUS_ACTIVE': {
                   'msgstr': [
@@ -129,7 +129,7 @@ module('Unit | Service | l10n', function(hooks) {
       autoInitialize: false,
       _window: {
         navigator: {
-          language: 'en'
+          languages: ['en']
         }
       }
     });
@@ -140,7 +140,7 @@ module('Unit | Service | l10n', function(hooks) {
       'English is default locale.'
     );
 
-      assert.strictEqual(
+    assert.strictEqual(
       service.n(
         'You have {{count}} unit in your cart.',
         'You have {{count}} units in your cart.',
@@ -276,7 +276,7 @@ module('Unit | Service | l10n', function(hooks) {
   test('detect and swap locale test', async function(assert) {
     let _window = {
       navigator: {
-        language: null
+        languages: []
       }
     };
     let service = this.owner.factoryFor('service:l10n').create({
@@ -292,7 +292,7 @@ module('Unit | Service | l10n', function(hooks) {
 
     assert.strictEqual(service.detectLocale(), 'de', '`defaultLocale` is used on failed detection.');
 
-    set(_window, 'navigator.language', 'it');
+    set(_window, 'navigator.languages', ['it']);
 
     assert.strictEqual(service.detectLocale(), 'it', 'Detected locale is used if listed in `availableLocales`.');
 
@@ -313,4 +313,36 @@ module('Unit | Service | l10n', function(hooks) {
     assert.strictEqual(service.getLocale(), 'de', 'Changing locales via `setLocale()` changes for supported locales.');
     assert.strictEqual(service.t('testing'), 'Test', 'Changing locales via `setLocale()` loads corresponding translations.');
   });
+
+  test('_getBrowserLocales works', function(assert) {
+    let _window = {
+      navigator: {
+        languages: []
+      }
+    };
+    let service = this.owner.factoryFor('service:l10n').create({
+      autoInitialize: false,
+      defaultLocale: 'de',
+      _window
+    });
+    assert.deepEqual(service._getBrowserLocales(), ['de'], 'it returns the default locale if empty languages is found');
+
+    set(service, '_window', {
+      navigator: {
+        languages: undefined,
+        browserLanguage: 'en'
+      }
+    });
+    assert.deepEqual(service._getBrowserLocales(), ['en'], 'it uses the browserLanguage if languages is not found');
+
+
+    set(service, '_window', {
+      navigator: {
+        languages: ['de-AT', 'de', 'en-US', 'en']
+      }
+    });
+    assert.deepEqual(service._getBrowserLocales(), ['de-AT', 'de', 'en-US', 'en'], 'it uses the languages if found');
+
+  });
+
 });

--- a/tests/unit/utils/guess-locale-test.js
+++ b/tests/unit/utils/guess-locale-test.js
@@ -1,0 +1,40 @@
+import { guessLocale } from 'ember-l10n/utils/guess-locale';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | guess-locale', function() {
+
+  test('it works', function(assert) {
+    let result = guessLocale();
+    assert.equal(result, 'en', 'it works with no input data');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['de-AT', 'de', 'en-US', 'en']);
+    assert.equal(result, 'de');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['de', 'en-US', 'en']);
+    assert.equal(result, 'de');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['de_at', 'en-US', 'en'],);
+    assert.equal(result, 'de');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['de_at', 'en-US', 'en'], { allowSubLocales: true });
+    assert.equal(result, 'de_AT');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['es-ES', 'es']);
+    assert.equal(result, 'en');
+  });
+
+  test('it works for Chinese variants', function(assert) {
+    let result = guessLocale(['en', 'de', 'zh_HK'], ['zh_CN', 'zh-hk', 'de-AT', 'de', 'en-US', 'en']);
+    assert.equal(result, 'zh_HK');
+
+    result = guessLocale(['en', 'de', 'zh_HK'], ['zh_CN', 'zh-hk', 'de-AT', 'de', 'en-US', 'en']);
+    assert.equal(result, 'zh_HK');
+
+    result = guessLocale(['en', 'de', 'zh_HK', 'zh_CN'], ['zh-SG', 'de-AT', 'de', 'en-US', 'en']);
+    assert.equal(result, 'zh_CN');
+
+    result = guessLocale(['en', 'de', 'zh_HK', 'zh_CN'], ['zh-MO', 'de-AT', 'de', 'en-US', 'en']);
+    assert.equal(result, 'zh_HK');
+  });
+
+});


### PR DESCRIPTION
This PR improves the `detectLocale` function to better take sub-locales into account.
This is necessary when dealing with e.g. Chinese, where zh_HK is a different language from zh_CN.

Now, it will compare the list from `window.navigator.languages` (which returns something like `['de-AT', 'de', 'en']`) with the list of allowed locales, and tries to pick the best one.

Additionally, it also exposes this functionality in a new function `guessBrowserLocale()`.