### PR TITLE
Strip comments for convert

### DIFF
--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -117,6 +117,7 @@ CREATING JSON FILE
 
     let poData = fs.readFileSync(poFile);
     let jsonData = parser.po.parse(poData);
+    this._stripCommentsFromJSON(jsonData);
 
     let validationErrors = this.validate(jsonData);
     this._printValidationErrors(validationErrors);
@@ -131,6 +132,26 @@ CREATING JSON FILE
     }
 
     this.ui.writeLine(chalk.green.bold(`\nFINISHED ✔`));
+  },
+
+  /**
+   * Remove all comments from the generated JSON.
+   * The comments are not needed by ember-l10n, and just add considerable size that the end user needs to download.
+   * Note that this modifies the given object.
+   *
+   * @method _stripCommentsFromJSON
+   * @param {Object} json
+   * @private
+   */
+  _stripCommentsFromJSON(json) {
+    let { translations } = json;
+
+    Object.keys(translations).forEach((namespace) => {
+      Object.keys(translations[namespace]).forEach((k) => {
+        let item = translations[namespace][k];
+        delete item.comments;
+      });
+    });
   },
 
   /**

--- a/node-tests/acceptance/commands/convert-test.js
+++ b/node-tests/acceptance/commands/convert-test.js
@@ -1,0 +1,77 @@
+const { expect } = require('chai');
+const path = require('path');
+const fs = require('fs');
+const shell = require('shelljs');
+const rimraf = require('rimraf');
+const Command = require('ember-cli/lib/models/command');
+const MockUI = require('console-ui/mock');
+const ConvertCommand = require('./../../../lib/commands/convert');
+
+function getOptions(options = {}) {
+  return Object.assign({
+    convertFrom: './tmp/ember-l10n-tests',
+    convertTo: './tmp/ember-l10n-tests',
+    language: 'en',
+    validateThrow: null,
+    dryRun: false
+  }, options);
+}
+
+function readJSONFromFile(fileName) {
+  let fileContent = fs.readFileSync(fileName, 'UTF-8');
+  return JSON.parse(fileContent);
+}
+
+describe('convert command', function() {
+  let project;
+  let tmpDir = './tmp/ember-l10n-tests';
+
+  this.timeout(100000);
+
+  beforeEach(function() {
+    project = {
+      root: path.resolve('.'),
+      addonPackages: {},
+      hasDependencies() {
+        return true;
+      },
+      isEmberCLIProject() {
+        return true;
+      }
+    };
+
+    shell.mkdir('-p', tmpDir)
+  });
+
+  afterEach(function() {
+    rimraf.sync(tmpDir);
+  });
+
+  function createCommand(options = {}) {
+    Object.assign(options, {
+      ui: new MockUI(),
+      project: project,
+      environment: {},
+      settings: {}
+    });
+
+    let TestCommand = Command.extend(ConvertCommand);
+    return new TestCommand(options);
+  }
+
+  it('it correctly converts a po file', async function() {
+    let options = getOptions({});
+
+    // First put the example en.po in the output folder
+    fs.copyFileSync('./node-tests/fixtures/convert/en.po', `${options.convertFrom}/en.po`);
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    let actualFileContent = readJSONFromFile('./tmp/ember-l10n-tests/en.json');
+    let expectedFileContent = readJSONFromFile('./node-tests/fixtures/convert/expected.json');
+
+    expect(actualFileContent).to.deep.equals(expectedFileContent);
+  });
+
+});

--- a/node-tests/fixtures/convert/en.po
+++ b/node-tests/fixtures/convert/en.po
@@ -1,0 +1,88 @@
+# English translations for My App package.
+# Copyright (C) 2018 My Company
+# This file is distributed under the same license as the My App package.
+# Automatically generated, 2018.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: My App 1.0\n"
+"Report-Msgid-Bugs-To: support@mycompany.com\n"
+"POT-Creation-Date: 2018-07-20 08:39+0200\n"
+"PO-Revision-Date: 2018-07-20 08:39+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: tests/dummy/app/services/l10n.js:7 tests/unit/services/l10n-test.js:169
+msgid "en"
+msgstr "en"
+
+#: tests/dummy/app/services/l10n.js:8
+msgid "de"
+msgstr "de"
+
+#: tests/dummy/app/services/l10n.js:9
+msgid "ko"
+msgstr "ko"
+
+#: tests/unit/services/l10n-test.js:145 tests/unit/services/l10n-test.js:203
+#: tests/unit/services/l10n-test.js:214 tests/unit/services/l10n-test.js:224
+#: tests/unit/services/l10n-test.js:235
+msgid "You have {{count}} unit in your cart."
+msgid_plural "You have {{count}} units in your cart."
+msgstr[0] "You have {{count}} unit in your cart."
+msgstr[1] "You have {{count}} units in your cart."
+
+#: tests/unit/services/l10n-test.js:176
+msgid "I'm a {{placeholder}}."
+msgstr "I'm a {{placeholder}}."
+
+#: tests/unit/services/l10n-test.js:186
+msgid "STATUS_ACTIVE"
+msgstr "STATUS_ACTIVE"
+
+#: tests/unit/services/l10n-test.js:185
+msgid "Current status: {{status}}"
+msgstr "Current status: {{status}}"
+
+#: tests/unit/services/l10n-test.js:247 tests/unit/services/l10n-test.js:253
+msgctxt "menu"
+msgid "user"
+msgid_plural "users"
+msgstr[0] "user"
+msgstr[1] "users"
+
+#: tests/unit/services/l10n-test.js:260
+msgctxt "menu"
+msgid "You have {{count}} subscription"
+msgid_plural "You have {{count}} subscriptions"
+msgstr[0] "You have {{count}} subscription"
+msgstr[1] "You have {{count}} subscriptions"
+
+#: tests/unit/services/l10n-test.js:314
+msgid "testing"
+msgstr "testing"
+
+#: tests/dummy/app/templates/application.hbs:24
+msgid "Hello world!"
+msgstr "Hello world!"
+
+#: tests/dummy/app/templates/application.hbs:63
+msgid "My name is {{name}}."
+msgstr "My name is {{name}}."
+
+#: tests/dummy/app/templates/application.hbs:89
+msgid "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+msgstr "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+
+#: tests/dummy/app/templates/application.hbs:71
+msgctxt "menu"
+msgid "User"
+msgstr "User"
+
+#~ msgid "asdasd"
+#~ msgstr "asdasd"

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -17,45 +17,30 @@
     "": {
       "": {
         "msgid": "",
-        "comments": {
-          "translator": "English translations for My App package.\nCopyright (C) 2018 My Company\nThis file is distributed under the same license as the My App package.\nAutomatically generated, 2018.\n"
-        },
         "msgstr": [
           "Project-Id-Version: My App 1.0\nReport-Msgid-Bugs-To: support@mycompany.com\nPOT-Creation-Date: 2018-07-20 08:39+0200\nPO-Revision-Date: 2018-07-20 08:39+0200\nLast-Translator: Automatically generated\nLanguage-Team: none\nLanguage: en\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1);\n"
         ]
       },
       "en": {
         "msgid": "en",
-        "comments": {
-          "reference": "tests/dummy/app/services/l10n.js:7 tests/unit/services/l10n-test.js:169"
-        },
         "msgstr": [
           "en"
         ]
       },
       "de": {
         "msgid": "de",
-        "comments": {
-          "reference": "tests/dummy/app/services/l10n.js:8"
-        },
         "msgstr": [
           "de"
         ]
       },
       "ko": {
         "msgid": "ko",
-        "comments": {
-          "reference": "tests/dummy/app/services/l10n.js:9"
-        },
         "msgstr": [
           "ko"
         ]
       },
       "You have {{count}} unit in your cart.": {
         "msgid": "You have {{count}} unit in your cart.",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:145 tests/unit/services/l10n-test.js:203\ntests/unit/services/l10n-test.js:214 tests/unit/services/l10n-test.js:224\ntests/unit/services/l10n-test.js:235"
-        },
         "msgid_plural": "You have {{count}} units in your cart.",
         "msgstr": [
           "You have {{count}} unit in your cart.",
@@ -64,63 +49,42 @@
       },
       "I'm a {{placeholder}}.": {
         "msgid": "I'm a {{placeholder}}.",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:176"
-        },
         "msgstr": [
           "I'm a {{placeholder}}."
         ]
       },
       "STATUS_ACTIVE": {
         "msgid": "STATUS_ACTIVE",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:186"
-        },
         "msgstr": [
           "STATUS_ACTIVE"
         ]
       },
       "Current status: {{status}}": {
         "msgid": "Current status: {{status}}",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:185"
-        },
         "msgstr": [
           "Current status: {{status}}"
         ]
       },
       "testing": {
         "msgid": "testing",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:314"
-        },
         "msgstr": [
           "testing"
         ]
       },
       "Hello world!": {
         "msgid": "Hello world!",
-        "comments": {
-          "reference": "tests/dummy/app/templates/application.hbs:24"
-        },
         "msgstr": [
           "Hello world!"
         ]
       },
       "My name is {{name}}.": {
         "msgid": "My name is {{name}}.",
-        "comments": {
-          "reference": "tests/dummy/app/templates/application.hbs:63"
-        },
         "msgstr": [
           "My name is {{name}}."
         ]
       },
       "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.": {
         "msgid": "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.",
-        "comments": {
-          "reference": "tests/dummy/app/templates/application.hbs:89"
-        },
         "msgstr": [
           "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
         ]
@@ -130,9 +94,6 @@
       "user": {
         "msgid": "user",
         "msgctxt": "menu",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:247 tests/unit/services/l10n-test.js:253"
-        },
         "msgid_plural": "users",
         "msgstr": [
           "user",
@@ -142,9 +103,6 @@
       "You have {{count}} subscription": {
         "msgid": "You have {{count}} subscription",
         "msgctxt": "menu",
-        "comments": {
-          "reference": "tests/unit/services/l10n-test.js:260"
-        },
         "msgid_plural": "You have {{count}} subscriptions",
         "msgstr": [
           "You have {{count}} subscription",
@@ -154,9 +112,6 @@
       "User": {
         "msgid": "User",
         "msgctxt": "menu",
-        "comments": {
-          "reference": "tests/dummy/app/templates/application.hbs:71"
-        },
         "msgstr": [
           "User"
         ]

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -1,0 +1,166 @@
+{
+  "charset": "utf-8",
+  "headers": {
+    "project-id-version": "My App 1.0",
+    "report-msgid-bugs-to": "support@mycompany.com",
+    "pot-creation-date": "2018-07-20 08:39+0200",
+    "po-revision-date": "2018-07-20 08:39+0200",
+    "last-translator": "Automatically generated",
+    "language-team": "none",
+    "language": "en",
+    "mime-version": "1.0",
+    "content-type": "text/plain; charset=UTF-8",
+    "content-transfer-encoding": "8bit",
+    "plural-forms": "nplurals=2; plural=(n != 1);"
+  },
+  "translations": {
+    "": {
+      "": {
+        "msgid": "",
+        "comments": {
+          "translator": "English translations for My App package.\nCopyright (C) 2018 My Company\nThis file is distributed under the same license as the My App package.\nAutomatically generated, 2018.\n"
+        },
+        "msgstr": [
+          "Project-Id-Version: My App 1.0\nReport-Msgid-Bugs-To: support@mycompany.com\nPOT-Creation-Date: 2018-07-20 08:39+0200\nPO-Revision-Date: 2018-07-20 08:39+0200\nLast-Translator: Automatically generated\nLanguage-Team: none\nLanguage: en\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1);\n"
+        ]
+      },
+      "en": {
+        "msgid": "en",
+        "comments": {
+          "reference": "tests/dummy/app/services/l10n.js:7 tests/unit/services/l10n-test.js:169"
+        },
+        "msgstr": [
+          "en"
+        ]
+      },
+      "de": {
+        "msgid": "de",
+        "comments": {
+          "reference": "tests/dummy/app/services/l10n.js:8"
+        },
+        "msgstr": [
+          "de"
+        ]
+      },
+      "ko": {
+        "msgid": "ko",
+        "comments": {
+          "reference": "tests/dummy/app/services/l10n.js:9"
+        },
+        "msgstr": [
+          "ko"
+        ]
+      },
+      "You have {{count}} unit in your cart.": {
+        "msgid": "You have {{count}} unit in your cart.",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:145 tests/unit/services/l10n-test.js:203\ntests/unit/services/l10n-test.js:214 tests/unit/services/l10n-test.js:224\ntests/unit/services/l10n-test.js:235"
+        },
+        "msgid_plural": "You have {{count}} units in your cart.",
+        "msgstr": [
+          "You have {{count}} unit in your cart.",
+          "You have {{count}} units in your cart."
+        ]
+      },
+      "I'm a {{placeholder}}.": {
+        "msgid": "I'm a {{placeholder}}.",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:176"
+        },
+        "msgstr": [
+          "I'm a {{placeholder}}."
+        ]
+      },
+      "STATUS_ACTIVE": {
+        "msgid": "STATUS_ACTIVE",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:186"
+        },
+        "msgstr": [
+          "STATUS_ACTIVE"
+        ]
+      },
+      "Current status: {{status}}": {
+        "msgid": "Current status: {{status}}",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:185"
+        },
+        "msgstr": [
+          "Current status: {{status}}"
+        ]
+      },
+      "testing": {
+        "msgid": "testing",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:314"
+        },
+        "msgstr": [
+          "testing"
+        ]
+      },
+      "Hello world!": {
+        "msgid": "Hello world!",
+        "comments": {
+          "reference": "tests/dummy/app/templates/application.hbs:24"
+        },
+        "msgstr": [
+          "Hello world!"
+        ]
+      },
+      "My name is {{name}}.": {
+        "msgid": "My name is {{name}}.",
+        "comments": {
+          "reference": "tests/dummy/app/templates/application.hbs:63"
+        },
+        "msgstr": [
+          "My name is {{name}}."
+        ]
+      },
+      "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.": {
+        "msgid": "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.",
+        "comments": {
+          "reference": "tests/dummy/app/templates/application.hbs:89"
+        },
+        "msgstr": [
+          "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+        ]
+      }
+    },
+    "menu": {
+      "user": {
+        "msgid": "user",
+        "msgctxt": "menu",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:247 tests/unit/services/l10n-test.js:253"
+        },
+        "msgid_plural": "users",
+        "msgstr": [
+          "user",
+          "users"
+        ]
+      },
+      "You have {{count}} subscription": {
+        "msgid": "You have {{count}} subscription",
+        "msgctxt": "menu",
+        "comments": {
+          "reference": "tests/unit/services/l10n-test.js:260"
+        },
+        "msgid_plural": "You have {{count}} subscriptions",
+        "msgstr": [
+          "You have {{count}} subscription",
+          "You have {{count}} subscriptions"
+        ]
+      },
+      "User": {
+        "msgid": "User",
+        "msgctxt": "menu",
+        "comments": {
+          "reference": "tests/dummy/app/templates/application.hbs:71"
+        },
+        "msgstr": [
+          "User"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This ensures that comments are stripped from the generated JSON files, as they are not needed by ember-l10n and add considerable size to the generated JSON (up to 50% of total size!).

I also added a basic test for the `ember l10n:convert` command.

This fixes #45 .