### PR TITLE
Fix quotes

### DIFF
--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -8,6 +8,7 @@ let shell = require('shelljs');
 let parser = require('gettext-parser');
 let AbstractCommand = require('./abstract');
 let BaseCommand = Object.create(AbstractCommand);
+let { validate } = require('./utils/validate-json');
 
 // enable error reporting
 shell.config.fatal = true;
@@ -119,7 +120,7 @@ CREATING JSON FILE
     let jsonData = parser.po.parse(poData);
     this._stripCommentsFromJSON(jsonData);
 
-    let validationErrors = this.validate(jsonData);
+    let validationErrors = validate(jsonData);
     this._printValidationErrors(validationErrors);
 
     if (this._shouldThrowForValidation(validationErrors, options.validateThrow)) {
@@ -151,177 +152,6 @@ CREATING JSON FILE
         let item = translations[namespace][k];
         delete item.comments;
       });
-    });
-  },
-
-  /**
-   * Validate a given JSON object for correct syntax.
-   * This returns an array of error objects.
-   *
-   * @method validate
-   * @param {Object} json
-   * @return {Object[]}
-   * @protected
-   */
-  _validationErrors: [],
-  validate(json) {
-    let { translations } = json;
-    this._validationErrors = [];
-
-    Object.keys(translations).forEach((namespace) => {
-      Object.keys(translations[namespace]).forEach((k) => {
-        this._validateItem(translations[namespace][k]);
-      });
-    });
-
-    return this._validationErrors;
-  },
-
-  /**
-   * Validate one translation item.
-   * This mutates this._validationErrors.
-   *
-   * @method _validateItem
-   * @param {Object }item
-   * @private
-   */
-  _validateItem(item) {
-    let { msgid: id, msgid_plural: idPlural, msgstr: translations } = item;
-
-    this._validatePlaceholders({ id, idPlural, translations });
-    this._validateTranslatedPlaceholders({ id, translations });
-  },
-
-  /**
-   * Validate the regular placeholders of an item.
-   * This possibly modifies this._validationErrors.
-   *
-   * @method _validatePlaceholder
-   * @param {String} id
-   * @param {String} idPlural
-   * @param {String[]} translations
-   * @private
-   */
-  _validatePlaceholders({ id, idPlural, translations }) {
-    // search for {{placeholderName}}
-    // Also search for e.g. Chinese symbols in the placeholderName
-    let pattern = /{{\s*(\S+?)\s*?}}/g;
-    let placeholders = id.match(pattern) || [];
-
-    // We also want to add placeholders from the plural string
-    if (idPlural) {
-      let pluralPlaceholders = idPlural.match(pattern) || [];
-      pluralPlaceholders.forEach((placeholder) => {
-        if (!placeholders.includes(placeholder)) {
-          placeholders.push(placeholder);
-        }
-      });
-    }
-
-    if (!placeholders.length) {
-      return;
-    }
-
-    translations.forEach((translation) => {
-      let translatedPlaceholders = translation.match(pattern) || [];
-
-      // Search for placeholders in the translated string that are not in the original string
-      let invalidPlaceholder = translatedPlaceholders.find((placeholder) => !placeholders.includes(placeholder));
-      if (invalidPlaceholder) {
-        this._validationErrors.push({
-          id,
-          translation,
-          message: `The placeholder "${invalidPlaceholder}" seems to be wrongly translated. Allowed: ${placeholders.join(', ')}`,
-          level: 'ERROR'
-        });
-      }
-    });
-  },
-
-  /**
-   * Validate the translated (complex) placeholders of an item.
-   * This mutates this._validationErrors.
-   *
-   * @method _validateTranslatedPlaceholders
-   * @param {String} id
-   * @param {String[]} translations
-   * @private
-   */
-  _validateTranslatedPlaceholders({ id, translations }) {
-    // find all: {{placeholder 'also translated'}}
-    // {{placeholder "also translated"}}
-    // {{placeholder \'also translated\'}}
-    // {{placeholder \"also translated\"}}
-    let pattern = /{{\s*([\w]+)\s+((\\')|(\\")|"|')(.*?)((\\')|(\\")|"|')\s*}}/g;
-
-    // This only works in non-plural form, so we assume only one translation
-    let [translation] = translations;
-
-    // Build an object describing the complex placeholders from the original string
-    let placeholders = id.match(pattern) || [];
-    if (!placeholders.length) {
-      return;
-    }
-    let placeholderConfig = placeholders.map((str) => {
-      pattern.lastIndex = 0;
-      let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
-      return {
-        fullResult,
-        placeholder,
-        quoteSymbol1,
-        quoteSymbol2,
-        content
-      };
-    });
-
-    // Build an object describing the complex placeholders from the translated string
-    let translatedPlaceholders = translation.match(pattern) || [];
-    let translatedPlaceholderConfig = translatedPlaceholders.map((str) => {
-      pattern.lastIndex = 0;
-      let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
-      return {
-        fullResult,
-        placeholder,
-        quoteSymbol1,
-        quoteSymbol2,
-        content
-      };
-    });
-
-    placeholderConfig.forEach(({ placeholder, content }) => {
-      // First we check for missing/invalid placeholders
-      // This can happen e.g. if a translator changes {{placeholder 'test'}} to {{placeholder `test`}}
-      // So we make sure that all originally defined placeholders actually still exist
-      if (!translatedPlaceholderConfig.find((config) => config.placeholder === placeholder)) {
-        this._validationErrors.push({
-          id,
-          translation,
-          message: `The complex placeholder "${placeholder}" is not correctly translated`,
-          level: 'ERROR'
-        });
-        return;
-      }
-
-      // Then, we check if the placeholder content is correctly translated
-      // If the whole string is not translated at all, we ignore it
-      // Only if the string is translated but the placeholder part not will this show a warning
-      // NOTE: This is just a warning (not an error), as it is theoretically possible this is done on purpose
-      // E.g. a word _might_ be the same in translated form
-      if (id === translation) {
-        return;
-      }
-      let invalidTranslatedPlaceholder = translatedPlaceholderConfig.find((config) => {
-        return config.content === content;
-      });
-
-      if (invalidTranslatedPlaceholder) {
-        this._validationErrors.push({
-          id,
-          translation,
-          message: `The content "${content}" for complex placeholder "${placeholder}" is not translated`,
-          level: 'WARNING'
-        });
-      }
     });
   },
 

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -9,6 +9,7 @@ let parser = require('gettext-parser');
 let AbstractCommand = require('./abstract');
 let BaseCommand = Object.create(AbstractCommand);
 let { validate } = require('./utils/validate-json');
+let { traverseJson } = require('./utils/traverse-json');
 
 // enable error reporting
 shell.config.fatal = true;
@@ -118,7 +119,7 @@ CREATING JSON FILE
 
     let poData = fs.readFileSync(poFile);
     let jsonData = parser.po.parse(poData);
-    this._stripCommentsFromJSON(jsonData);
+    this._processJSON(jsonData);
 
     let validationErrors = validate(jsonData);
     this._printValidationErrors(validationErrors);
@@ -136,22 +137,39 @@ CREATING JSON FILE
   },
 
   /**
-   * Remove all comments from the generated JSON.
-   * The comments are not needed by ember-l10n, and just add considerable size that the end user needs to download.
-   * Note that this modifies the given object.
+   * Process the generated JSON object, to optimize it for ember-l10n.
+   * This mutates the given JSON object.
    *
-   * @method _stripCommentsFromJSON
+   * @method _processJSON
    * @param {Object} json
    * @private
    */
-  _stripCommentsFromJSON(json) {
-    let { translations } = json;
+  _processJSON(json) {
+    traverseJson(json, (item) => {
+      // Remove comments, as we don't need them
+      delete item.comments;
 
-    Object.keys(translations).forEach((namespace) => {
-      Object.keys(translations[namespace]).forEach((k) => {
-        let item = translations[namespace][k];
-        delete item.comments;
-      });
+      // Fix curly single/double quotes, to ensure translations work
+      this._fixCurlyQuotes(item);
+    });
+  },
+
+  /**
+   * Fix quotes in translations.
+   * This will replace curly double/single quotes with regular quotes, to ensure the generated JSON files work.
+   *
+   * @method _fixCurlyQuotes
+   * @param {Object} item
+   * @private
+   */
+  _fixCurlyQuotes(item) {
+    let doubleQuoteRegex = /[“|”]/gm;
+    let singleQuoteRegex = /[‘|’]/gm;
+
+    item.msgstr = item.msgstr.map((str) => {
+      return str
+        .replace(doubleQuoteRegex, '"')
+        .replace(singleQuoteRegex, '\'');
     });
   },
 

--- a/lib/commands/utils/traverse-json.js
+++ b/lib/commands/utils/traverse-json.js
@@ -1,0 +1,29 @@
+/* eslint-env node */
+
+/**
+ * This will traverse an l10n-JSON file, and call the callback function for each translation item.
+ *
+ * For example:
+ *
+ * ```js
+ * traverseJson(json, (item) => delete item.comment);
+ * ```
+ *
+ * @method traverseJson
+ * @param {Object} json
+ * @param {Function} callback
+ * @public
+ */
+function traverseJson(json, callback) {
+  let { translations } = json;
+
+  Object.keys(translations).forEach((namespace) => {
+    Object.keys(translations[namespace]).forEach((k) => {
+      callback(translations[namespace][k]);
+    });
+  });
+}
+
+module.exports = {
+  traverseJson
+};

--- a/lib/commands/utils/validate-json.js
+++ b/lib/commands/utils/validate-json.js
@@ -1,17 +1,11 @@
 /* eslint-env node */
 const { validatePlaceholders } = require('./validate/validate-placeholders');
 const { validateTranslatedPlaceholders } = require('./validate/validate-translated-placeholders');
+const { traverseJson } = require('./traverse-json');
 
 function validate(json) {
-  let { translations } = json;
   let validationErrors = [];
-
-  Object.keys(translations).forEach((namespace) => {
-    Object.keys(translations[namespace]).forEach((k) => {
-      validateItem(translations[namespace][k], validationErrors);
-    });
-  });
-
+  traverseJson(json, (item) => validateItem(item, validationErrors));
   return validationErrors
 }
 

--- a/lib/commands/utils/validate-json.js
+++ b/lib/commands/utils/validate-json.js
@@ -1,0 +1,28 @@
+/* eslint-env node */
+const { validatePlaceholders } = require('./validate/validate-placeholders');
+const { validateTranslatedPlaceholders } = require('./validate/validate-translated-placeholders');
+
+function validate(json) {
+  let { translations } = json;
+  let validationErrors = [];
+
+  Object.keys(translations).forEach((namespace) => {
+    Object.keys(translations[namespace]).forEach((k) => {
+      validateItem(translations[namespace][k], validationErrors);
+    });
+  });
+
+  return validationErrors
+}
+
+function validateItem(item, validationErrors) {
+  let { msgid: id, msgid_plural: idPlural, msgstr: translations } = item;
+
+  validatePlaceholders({ id, idPlural, translations }, validationErrors);
+  validateTranslatedPlaceholders({ id, translations }, validationErrors);
+}
+
+module.exports = {
+  validate,
+  validateItem
+};

--- a/lib/commands/utils/validate/validate-placeholders.js
+++ b/lib/commands/utils/validate/validate-placeholders.js
@@ -1,0 +1,51 @@
+/* eslint-env node */
+
+/**
+ * Validate the regular placeholders of an item.
+ * This possibly modifies the given validationErrors.
+ *
+ * @method _validatePlaceholder
+ * @param {String} id
+ * @param {String} idPlural
+ * @param {String[]} translations
+ * @private
+ */
+function validatePlaceholders({ id, idPlural, translations }, validationErrors) {
+  // search for {{placeholderName}}
+  // Also search for e.g. Chinese symbols in the placeholderName
+  let pattern = /{{\s*(\S+?)\s*?}}/g;
+  let placeholders = id.match(pattern) || [];
+
+  // We also want to add placeholders from the plural string
+  if (idPlural) {
+    let pluralPlaceholders = idPlural.match(pattern) || [];
+    pluralPlaceholders.forEach((placeholder) => {
+      if (!placeholders.includes(placeholder)) {
+        placeholders.push(placeholder);
+      }
+    });
+  }
+
+  if (!placeholders.length) {
+    return;
+  }
+
+  translations.forEach((translation) => {
+    let translatedPlaceholders = translation.match(pattern) || [];
+
+    // Search for placeholders in the translated string that are not in the original string
+    let invalidPlaceholder = translatedPlaceholders.find((placeholder) => !placeholders.includes(placeholder));
+    if (invalidPlaceholder) {
+      validationErrors.push({
+        id,
+        translation,
+        message: `The placeholder "${invalidPlaceholder}" seems to be wrongly translated. Allowed: ${placeholders.join(', ')}`,
+        level: 'ERROR'
+      });
+    }
+  });
+}
+
+module.exports = {
+  validatePlaceholders
+};

--- a/lib/commands/utils/validate/validate-translated-placeholders.js
+++ b/lib/commands/utils/validate/validate-translated-placeholders.js
@@ -1,0 +1,92 @@
+/* eslint-env node */
+
+/**
+ * Validate the translated (complex) placeholders of an item.
+ * This mutates the given validationErrors.
+ *
+ * @method _validateTranslatedPlaceholders
+ * @param {String} id
+ * @param {String[]} translations
+ * @private
+ */
+function validateTranslatedPlaceholders({ id, translations }, validationErrors) {
+  // find all: {{placeholder 'also translated'}}
+  // {{placeholder "also translated"}}
+  // {{placeholder \'also translated\'}}
+  // {{placeholder \"also translated\"}}
+  let pattern = /{{\s*([\w]+)\s+((\\')|(\\")|"|')(.*?)((\\')|(\\")|"|')\s*}}/g;
+
+  // This only works in non-plural form, so we assume only one translation
+  let [translation] = translations;
+
+  // Build an object describing the complex placeholders from the original string
+  let placeholders = id.match(pattern) || [];
+  if (!placeholders.length) {
+    return;
+  }
+  let placeholderConfig = placeholders.map((str) => {
+    pattern.lastIndex = 0;
+    let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
+    return {
+      fullResult,
+      placeholder,
+      quoteSymbol1,
+      quoteSymbol2,
+      content
+    };
+  });
+
+  // Build an object describing the complex placeholders from the translated string
+  let translatedPlaceholders = translation.match(pattern) || [];
+  let translatedPlaceholderConfig = translatedPlaceholders.map((str) => {
+    pattern.lastIndex = 0;
+    let [fullResult, placeholder, quoteSymbol1, , , content, quoteSymbol2] = pattern.exec(str);
+    return {
+      fullResult,
+      placeholder,
+      quoteSymbol1,
+      quoteSymbol2,
+      content
+    };
+  });
+
+  placeholderConfig.forEach(({ placeholder, content }) => {
+    // First we check for missing/invalid placeholders
+    // This can happen e.g. if a translator changes {{placeholder 'test'}} to {{placeholder `test`}}
+    // So we make sure that all originally defined placeholders actually still exist
+    if (!translatedPlaceholderConfig.find((config) => config.placeholder === placeholder)) {
+      validationErrors.push({
+        id,
+        translation,
+        message: `The complex placeholder "${placeholder}" is not correctly translated`,
+        level: 'ERROR'
+      });
+      return;
+    }
+
+    // Then, we check if the placeholder content is correctly translated
+    // If the whole string is not translated at all, we ignore it
+    // Only if the string is translated but the placeholder part not will this show a warning
+    // NOTE: This is just a warning (not an error), as it is theoretically possible this is done on purpose
+    // E.g. a word _might_ be the same in translated form
+    if (id === translation) {
+      return;
+    }
+    let invalidTranslatedPlaceholder = translatedPlaceholderConfig.find((config) => {
+      return config.content === content;
+    });
+
+    if (invalidTranslatedPlaceholder) {
+      validationErrors.push({
+        id,
+        translation,
+        message: `The content "${content}" for complex placeholder "${placeholder}" is not translated`,
+        level: 'WARNING'
+      });
+    }
+  });
+}
+
+module.exports = {
+    validateTranslatedPlaceholders
+};

--- a/node-tests/fixtures/convert/en.po
+++ b/node-tests/fixtures/convert/en.po
@@ -56,6 +56,10 @@ msgid_plural "users"
 msgstr[0] "user"
 msgstr[1] "users"
 
+#: tests/unit/services/l10n-test.js:248
+msgid "\"double quotes\" and 'single quotes'"
+msgstr "“double quotes” and ‘single quotes’"
+
 #: tests/unit/services/l10n-test.js:260
 msgctxt "menu"
 msgid "You have {{count}} subscription"

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -59,6 +59,12 @@
           "STATUS_ACTIVE"
         ]
       },
+      "\"double quotes\" and 'single quotes'": {
+        "msgid": "\"double quotes\" and 'single quotes'",
+        "msgstr": [
+          "\"double quotes\" and 'single quotes'"
+        ]
+      },
       "Current status: {{status}}": {
         "msgid": "Current status: {{status}}",
         "msgstr": [


### PR DESCRIPTION
Currently, it can happen that translators accidentally change quotes in .po files. This will break translations, e.g. when double or single quotes that are needed in the HTML are changed.

This PR changes `ember l10n:convert` to fix all curly single/double quotes to regular, straight single/double quotes.

It also extracts the validation functionality into dedicated utils, to keep the commands slimmer. 

This fixed #47.