### PR TITLE
Drop ember-ajax dependency

### DIFF
--- a/addon/services/l10n-ajax.js
+++ b/addon/services/l10n-ajax.js
@@ -1,6 +1,0 @@
-import Ajax from 'ember-ajax/services/ajax';
-
-export default Ajax.extend({
-  host: '',
-  namespace: ''
-});

--- a/addon/services/l10n.js
+++ b/addon/services/l10n.js
@@ -57,7 +57,6 @@ export default Service.extend({
   // -------------------------------------------------------------------------
   // Dependencies
 
-  ajax: service('l10n-ajax'),
   assetMap: service(),
 
   // -------------------------------------------------------------------------
@@ -749,9 +748,35 @@ export default Service.extend({
    * @public
    */
   _loadLocaleFile(locale) {
-    let ajax = get(this, 'ajax');
     let localeMap = get(this, '_localeMap');
-    return ajax.request(get(localeMap, locale));
+    let fileName = get(localeMap, locale);
+    return this.ajaxRequest(fileName);
+  },
+
+  /**
+   * Actually make the Ajax request.
+   *
+   * @method ajaxRequest
+   * @param {String} fileName
+   * @return {Promise<Object>}
+   * @protected
+   */
+  ajaxRequest(fileName) {
+    return new Promise((resolve, reject) => {
+      let request = new XMLHttpRequest();
+      request.open('GET', fileName);
+      request.addEventListener('load', function() {
+        try {
+          let { responseText } = this;
+          let json = JSON.parse(responseText);
+          resolve(json);
+        } catch(error) {
+          reject(error);
+        }
+      });
+      request.addEventListener('error', reject);
+      request.send();
+    });
   },
 
   /**

--- a/app/services/l10n-ajax.js
+++ b/app/services/l10n-ajax.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-l10n/services/l10n-ajax';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
     "chai": "^4.2.0",
-    "ember-ajax": "^4.0.0",
     "ember-cli": "~3.5.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-dependency-checker": "^3.0.0",

--- a/tests/integration/helpers/n-test.js
+++ b/tests/integration/helpers/n-test.js
@@ -4,77 +4,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import L10n from 'ember-l10n/services/l10n';
 import hbs from 'htmlbars-inline-precompile';
-import Service from '@ember/service';
 import wait from 'ember-test-helpers/wait';
-
-const mockAjax = Service.extend({
-  request(url) {
-    return {
-      then(func) {
-        let json = {
-          '/assets/locales/en.json': {
-            'headers': {
-              'language': 'en',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'I am one plural translation.': {
-                  'msgstr': [
-                    'I am one plural translation.',
-                    'We are multiple plural translations.'
-                  ]
-                },
-                'You have {{count}} unit in your cart.': {
-                  'msgstr': [
-                    'You have {{count}} unit in your cart.',
-                    'You have {{count}} units in your cart.'
-                  ]
-                }
-              }
-            }
-          },
-
-          '/assets/locales/de.json': {
-            'headers': {
-              'language': 'de',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'I am one plural translation.': {
-                  'msgstr': [
-                    'Ich bin eine Pluralübersetzung.',
-                    'Wir sind mehrere Pluralübersetzungen.'
-                  ]
-                },
-                'You have {{count}} unit in your cart.': {
-                  'msgstr': [
-                    'Du hast {{count}} Einheit in deinem Warenkorb.',
-                    'Du hast {{count}} Einheiten in deinem Warenkorb.'
-                  ]
-                }
-              }
-            }
-          }
-        };
-
-        func(json[url]);
-      }
-    };
-  }
-});
+import Pretender from 'pretender';
 
 const mockL10nService = L10n.extend({
-  ajax: mockAjax.create(),
   autoInitialize: false,
   availableLocales: {
     en: 'en',
     de: 'de'
   }
 });
-
-let l10nService;
 
 module('Integration | Helper | n', function(hooks) {
   setupRenderingTest(hooks);
@@ -83,11 +22,69 @@ module('Integration | Helper | n', function(hooks) {
     this.owner.register('service:l10n', mockL10nService);
     this.l10n = this.owner.lookup('service:l10n');
 
-    l10nService = this.owner.lookup('service:l10n');
+    this.server = new Pretender(function() {
+      let json = {
+        'en.json': {
+          'headers': {
+            'language': 'en',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'I am one plural translation.': {
+                'msgstr': [
+                  'I am one plural translation.',
+                  'We are multiple plural translations.'
+                ]
+              },
+              'You have {{count}} unit in your cart.': {
+                'msgstr': [
+                  'You have {{count}} unit in your cart.',
+                  'You have {{count}} units in your cart.'
+                ]
+              }
+            }
+          }
+        },
+
+        'de.json': {
+          'headers': {
+            'language': 'de',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'I am one plural translation.': {
+                'msgstr': [
+                  'Ich bin eine Pluralübersetzung.',
+                  'Wir sind mehrere Pluralübersetzungen.'
+                ]
+              },
+              'You have {{count}} unit in your cart.': {
+                'msgstr': [
+                  'Du hast {{count}} Einheit in deinem Warenkorb.',
+                  'Du hast {{count}} Einheiten in deinem Warenkorb.'
+                ]
+              }
+            }
+          }
+        }
+      };
+
+      this.get('/assets/locales/:locale', (request)=> {
+        let response = json[request.params.locale];
+        return [200, {}, JSON.stringify(response)];
+      })
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
   });
 
   test('it works', async function(assert) {
-    await l10nService.setLocale('en');
+    let { l10n } = this;
+    await l10n.setLocale('en');
 
     await render(hbs`{{n '<b>I am bold.</b>'}}`);
     assert.equal(this.element.innerHTML, '&lt;b&gt;I am bold.&lt;/b&gt;', 'It escapes text per default.');
@@ -109,7 +106,7 @@ module('Integration | Helper | n', function(hooks) {
     this.set('count', 5);
     assert.dom(this.element).hasText('You have 5 units in your cart.', 'Placeholder translations for count>1 are working.');
 
-    await l10nService.setLocale('de');
+    await l10n.setLocale('de');
     await wait();
 
     assert.dom(this.element).hasText('Du hast 5 Einheiten in deinem Warenkorb.', 'Changing locale recomputes translations properly.');

--- a/tests/integration/helpers/t-test.js
+++ b/tests/integration/helpers/t-test.js
@@ -4,73 +4,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import L10n from 'ember-l10n/services/l10n';
 import hbs from 'htmlbars-inline-precompile';
-import Service from '@ember/service';
 import wait from 'ember-test-helpers/wait';
-
-const mockAjax = Service.extend({
-  request(url) {
-    return {
-      then(func) {
-        let json = {
-          '/assets/locales/en.json': {
-            'headers': {
-              'language': 'en',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'en': {
-                  'msgstr': [
-                    'English'
-                  ]
-                },
-                'I\'m a {{placeholder}}.': {
-                  'msgstr': [
-                    'I\'m a {{placeholder}}.'
-                  ]
-                }
-              }
-            }
-          },
-
-          '/assets/locales/de.json': {
-            'headers': {
-              'language': 'de',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'en': {
-                  'msgstr': [
-                    'English'
-                  ]
-                },
-                'I\'m a {{placeholder}}.': {
-                  'msgstr': [
-                    'Ich bin ein {{placeholder}}.'
-                  ]
-                }
-              }
-            }
-          }
-        };
-
-        func(json[url]);
-      }
-    };
-  }
-});
+import Pretender from 'pretender';
 
 const mockL10nService = L10n.extend({
-  ajax: mockAjax.create(),
   autoInitialize: false,
   availableLocales: {
     en: 'en',
     de: 'de'
   }
 });
-
-let l10nService;
 
 module('Integration | Helper | t', function(hooks) {
   setupRenderingTest(hooks);
@@ -79,11 +22,65 @@ module('Integration | Helper | t', function(hooks) {
     this.owner.register('service:l10n', mockL10nService);
     this.l10n = this.owner.lookup('service:l10n');
 
-    l10nService = this.owner.lookup('service:l10n');
+    this.server = new Pretender(function() {
+      let json = {
+        'en.json': {
+          'headers': {
+            'language': 'en',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'en': {
+                'msgstr': [
+                  'English'
+                ]
+              },
+              'I\'m a {{placeholder}}.': {
+                'msgstr': [
+                  'I\'m a {{placeholder}}.'
+                ]
+              }
+            }
+          }
+        },
+
+        'de.json': {
+          'headers': {
+            'language': 'de',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'en': {
+                'msgstr': [
+                  'English'
+                ]
+              },
+              'I\'m a {{placeholder}}.': {
+                'msgstr': [
+                  'Ich bin ein {{placeholder}}.'
+                ]
+              }
+            }
+          }
+        }
+      };
+
+      this.get('/assets/locales/:locale', (request)=> {
+        let response = json[request.params.locale];
+        return [200, {}, JSON.stringify(response)];
+      })
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
   });
 
   test('it works', async function(assert) {
-    await l10nService.setLocale('en');
+    let { l10n } = this;
+    await l10n.setLocale('en');
 
     await render(hbs`{{t 'en'}}`);
     assert.dom(this.element).hasText('English', 'Common translations are working.');
@@ -95,7 +92,7 @@ module('Integration | Helper | t', function(hooks) {
     await render(hbs`{{t "I'm a {{placeholder}}." placeholder=value}}`);
     assert.dom(this.element).hasText('I\'m a PLACEHOLDER.', 'Placeholder translations are working.');
 
-    await l10nService.setLocale('de');
+    await l10n.setLocale('de');
     await wait();
 
     assert.dom(this.element).hasText('Ich bin ein PLACEHOLDER.', 'Changing locale recomputes translations properly.');

--- a/tests/integration/helpers/t-var-test.js
+++ b/tests/integration/helpers/t-var-test.js
@@ -4,73 +4,16 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import L10n from 'ember-l10n/services/l10n';
 import hbs from 'htmlbars-inline-precompile';
-import Service from '@ember/service';
 import wait from 'ember-test-helpers/wait';
-
-const mockAjax = Service.extend({
-  request(url) {
-    return {
-      then(func) {
-        let json = {
-          '/assets/locales/en.json': {
-            'headers': {
-              'language': 'en',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'en': {
-                  'msgstr': [
-                    'English'
-                  ]
-                },
-                'I\'m a {{placeholder}}.': {
-                  'msgstr': [
-                    'I\'m a {{placeholder}}.'
-                  ]
-                }
-              }
-            }
-          },
-
-          '/assets/locales/de.json': {
-            'headers': {
-              'language': 'de',
-              'plural-forms': 'nplurals=2; plural=(n != 1);'
-            },
-            'translations': {
-              '': {
-                'en': {
-                  'msgstr': [
-                    'English'
-                  ]
-                },
-                'I\'m a {{placeholder}}.': {
-                  'msgstr': [
-                    'Ich bin ein {{placeholder}}.'
-                  ]
-                }
-              }
-            }
-          }
-        };
-
-        func(json[url]);
-      }
-    };
-  }
-});
+import Pretender from 'pretender';
 
 const mockL10nService = L10n.extend({
-  ajax: mockAjax.create(),
   autoInitialize: false,
   availableLocales: {
     en: 'en',
     de: 'de'
   }
 });
-
-let l10nService;
 
 module('Integration | Helper | t-var', function(hooks) {
   setupRenderingTest(hooks);
@@ -79,11 +22,65 @@ module('Integration | Helper | t-var', function(hooks) {
     this.owner.register('service:l10n', mockL10nService);
     this.l10n = this.owner.lookup('service:l10n');
 
-    l10nService = this.owner.lookup('service:l10n');
+    this.server = new Pretender(function() {
+      let json = {
+        'en.json': {
+          'headers': {
+            'language': 'en',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'en': {
+                'msgstr': [
+                  'English'
+                ]
+              },
+              'I\'m a {{placeholder}}.': {
+                'msgstr': [
+                  'I\'m a {{placeholder}}.'
+                ]
+              }
+            }
+          }
+        },
+
+        'de.json': {
+          'headers': {
+            'language': 'de',
+            'plural-forms': 'nplurals=2; plural=(n != 1);'
+          },
+          'translations': {
+            '': {
+              'en': {
+                'msgstr': [
+                  'English'
+                ]
+              },
+              'I\'m a {{placeholder}}.': {
+                'msgstr': [
+                  'Ich bin ein {{placeholder}}.'
+                ]
+              }
+            }
+          }
+        }
+      };
+
+      this.get('/assets/locales/:locale', (request)=> {
+        let response = json[request.params.locale];
+        return [200, {}, JSON.stringify(response)];
+      })
+    });
+  });
+
+  hooks.afterEach(function() {
+    this.server.shutdown();
   });
 
   test('it works', async function(assert) {
-    await l10nService.setLocale('en');
+    let { l10n } = this;
+    await l10n.setLocale('en');
 
     await render(hbs`{{t-var 'en'}}`);
     assert.dom(this.element).hasText('English', 'Common translations are working.');
@@ -92,7 +89,7 @@ module('Integration | Helper | t-var', function(hooks) {
     await render(hbs`{{t-var "I'm a {{placeholder}}." placeholder=value}}`);
     assert.dom(this.element).hasText('I\'m a PLACEHOLDER.', 'Placeholder translations are working.');
 
-    await l10nService.setLocale('de');
+    await l10n.setLocale('de');
     await wait();
 
     assert.dom(this.element).hasText('Ich bin ein PLACEHOLDER.', 'Changing locale recomputes translations properly.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,14 +3458,6 @@ electron-to-chromium@^1.3.82:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.84.tgz#2e55df59e818f150a9f61b53471ebf4f0feecc65"
   integrity sha512-IYhbzJYOopiTaNWMBp7RjbecUBsbnbDneOP86f3qvS0G0xfzwNSvMJpTrvi5/Y1gU7tg2NAgeg8a8rCYvW9Whw==
 
-ember-ajax@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ember-ajax/-/ember-ajax-4.0.0.tgz#c21e97db81393f3f48c6e402139fb517bef1b421"
-  integrity sha512-IAdzj2u/fVMu57jlzMq/OSb4xp1Viyn52TyseWbjuPDr4Kn/Wz0HR40GckQdu+3vH3yJkh5aMzTIMTM7DCUlcw==
-  dependencies:
-    ember-cli-babel "^6.16.0"
-    najax "^1.0.3"
-
 ember-assign-polyfill@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/ember-assign-polyfill/-/ember-assign-polyfill-2.5.0.tgz#0dc7079addbdbad7984ba3f35d970cf07a73f704"
@@ -3538,25 +3530,6 @@ ember-cli-babel@^6.11.0:
     clone "^2.0.0"
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
-
-ember-cli-babel@^6.16.0:
-  version "6.17.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.17.2.tgz#f0d53d2fb95e70c15d8db84760d045f88f458f69"
-  integrity sha512-9KcCvF1PcelEFTSiJ/Ld20tfuW9acMkwHC/xINLsmwqJVDbm3oEqWtiFDZ5ebaC278O5I0GqNJWJLYNoWMNZ8g==
-  dependencies:
-    amd-name-resolver "1.2.0"
-    babel-plugin-debug-macros "^0.2.0-beta.6"
-    babel-plugin-ember-modules-api-polyfill "^2.5.0"
-    babel-plugin-transform-es2015-modules-amd "^6.24.0"
-    babel-polyfill "^6.26.0"
-    babel-preset-env "^1.7.0"
-    broccoli-babel-transpiler "^6.5.0"
-    broccoli-debug "^0.6.4"
-    broccoli-funnel "^2.0.0"
-    broccoli-source "^1.1.0"
-    clone "^2.0.0"
-    ember-cli-version-checker "^2.1.2"
-    semver "^5.5.0"
 
 ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.3:
   version "7.1.3"
@@ -6236,11 +6209,6 @@ isurl@^1.0.0-alpha5:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
 
-jquery-deferred@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-deferred/-/jquery-deferred-0.3.1.tgz#596eca1caaff54f61b110962b23cafea74c35355"
-  integrity sha1-WW7KHKr/VPYbEQlisjyv6nTDU1U=
-
 jquery@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
@@ -7510,15 +7478,6 @@ mute-stream@0.0.7, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-najax@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.4.tgz#63fd8dbf15d18f24dc895b3a16fec66c136b8084"
-  integrity sha512-wsSacA+RkgY1wxRxXCT3tdqzmamEv9PLeoV/ub9SlLf2RngbPMSqc3A7H35XJDfURC0twMmZsnPdsYPkuuFSVg==
-  dependencies:
-    jquery-deferred "^0.3.0"
-    lodash.defaultsdeep "^4.6.0"
-    qs "^6.2.0"
-
 nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
@@ -8446,7 +8405,7 @@ qs@6.5.1, qs@^6.4.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@^6.2.0, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==


### PR DESCRIPTION
Currently, we use ember-ajax to fetch our locale files. This uses `$.ajax()` under the hood, which is not really ideal. This PR switches this with `ember-ajax` instead, which is just a polyfill for fetch, and thus does not depend on jQuery. 

The actual change here is really small, most of the changes are for the tests, where I replaced the ajax service mock with pretender based mocks.

I guess this can be considered a breaking change, even though it shouldn't actually break for most people I guess - as somebody might have overwritten/extended the `l10n-ajax` service. 