### PR TITLE
Remove excluded option

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,7 @@
 /tmp/
 
 # dependencies
-/bower_components/
+/node-tests/fixtures
 
 # misc
 /coverage/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,11 +57,19 @@ module.exports = {
       },
       env: {
         browser: false,
-        node: true
+        node: true,
+        mocha: true
       },
       plugins: ['node'],
       rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
-        // add your custom rules and overrides for node files here
+        'node/no-unsupported-features/es-syntax': ['error', {
+          'version': '>=8.5.0',
+          'ignores': []
+        }],
+        'node/no-unsupported-features/node-builtins': ['error', {
+          'version': '>=8.5.0',
+          'ignores': []
+        }]
       })
     },
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Using the string extractor requires:
 
-* [GNU gettext](https://www.gnu.org/software/gettext/) - extracts strings from JS files & creates PO
+* [GNU gettext](https://www.gnu.org/software/gettext/) - Convert from/to .po & .pot files
 
 Besides, `ember-l10n` uses [ember-ajax](https://github.com/ember-cli/ember-ajax) to fetch locale data.
 
@@ -59,9 +59,6 @@ There are two primary parts to ember-l10n
 In the ember-l10n workflow, you use the `t`, and `n` helpers and `l10n.t()` / `l10n.n()` functions to define your strings in your project. Then you run the extractor script to generate pot and po files, which you send off to your translators. After receiving the translated po files for additional locales, you use the same script to convert them into json files. These json files are then loaded by ember-l10n in your application and replaced at runtime.
 
 `ember-l10n` provides powerful string substitution and even component substitution for dynamic strings. See the [Components](#components) section below.
-
-###### Usage hints:
-Unfortunately, ```xgettext``` doesn't support ES6 template strings ([at the moment](https://savannah.gnu.org/bugs/?50920)), but the addon provides an easy way to handle variables in strings, please refer to [Helpers](#helpers) and [Components](#components) sections.
 
 ## Ember Side
 
@@ -349,7 +346,7 @@ ember l10n:extract <options...>
     aliases: -e <value>
   --extract-from (Array) (Default: ['./app']) The directory from which to extract the strings
     aliases: -i <value>
-  --exclude-patterns (Array) (Default: []) List of regex patterns to put into a dedicated `excluded.pot` file (configured in config/l10n-extract.js)
+  --include-patterns (Array) (Default: []) List of regex patterns to include for extraction. Defaults to all files. (configured in config/l10n-extract.js)
     aliases: -x <value>
   --skip-patterns (Array) (Default: ['mirage','fixtures','styleguide']) List of regex patterns to completely ignore from extraction
     aliases: -s <value>
@@ -385,7 +382,6 @@ Once you have extracted message ids with `ember l10n:extract`, which creates a d
 
 If you have excluded some files from prior extractions with `-x`  and want to merge them with your messages.pot you can do:
 
-* `ember l10n:extract -g -f excluded.pot -t messages.pot` (merge POT files)
 * `ember l10n:extract -g -l en` (merge english PO file)
 * `ember l10n:extract -g -l de` (merge german PO file)
 

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -86,16 +86,16 @@ module.exports = Object.assign(BaseCommand, {
       description: 'The directory from which to extract the strings'
     },
     {
-      name: 'exclude-patterns',
+      name: 'include-patterns',
       type: Array,
-      aliases: ['x'],
+      aliases: ['ip'],
       default: [],
-      description: 'List of regex patterns to put into a dedicated `excluded.pot` file'
+      description: 'List of regex patterns to include for extraction. Defaults to all files.'
     },
     {
       name: 'skip-patterns',
       type: Array,
-      aliases: ['s'],
+      aliases: ['sp', 's'],
       default: ['mirage', 'fixtures', 'styleguide'],
       description: 'List of regex patterns to completely ignore from extraction'
     },
@@ -208,12 +208,11 @@ module.exports = Object.assign(BaseCommand, {
 
     // run JS and HBS extractions
     this.messageGettextItems = [];
-    this.excludedGettextItems = [];
+
     this._extractFromJS(options);
     this._extractFromHBS(options);
 
     // then initialize POT files
-    this._initPOTFile(options, this.potExcludeFile, this.excludedGettextItems);
     this._initPOTFile(options, this.potFile, this.messageGettextItems);
 
     // and create PO files afterwards
@@ -238,7 +237,9 @@ module.exports = Object.assign(BaseCommand, {
   _preCommand(options) {
     this.tryInvoke_(() => shell.mkdir('-p', this.tmpFolder));
 
-    this.excludeRegex = new RegExp(`(?:${options.excludePatterns.join('|') || 'a^'})`, 'g');
+    this.includeRegex = options.includePatterns.length
+      ? new RegExp(`(?:${options.includePatterns.join('|') || 'a^'})`, 'g')
+      : null;
     this.skipRegex = new RegExp(`(?:${options.skipPatterns.join('|') || 'a^'})`, 'g');
   },
 
@@ -288,11 +289,9 @@ module.exports = Object.assign(BaseCommand, {
    * @return {Void}
    */
   _makePOTFiles(options) {
-    this.potExcludeFile = `${this.tmpFolder}/excluded.pot`;
     this.potFile = `${this.tmpFolder}/${options.potName}`;
 
     this.tryInvoke_(() => {
-      shell.touch(this.potExcludeFile);
       shell.touch(this.potFile);
     });
   },
@@ -367,21 +366,18 @@ EXTRACTING JAVASCRIPT TRANSLATIONS
     );
 
     files.forEach(file => {
-      if (file.match(this.skipRegex)) {
+      if (this._shouldSkipFile(file)) {
         this.ui.writeLine(chalk.yellow(`Skipping ${file}...`));
         return;
       }
 
-      let isExcluded = file.match(this.excludeRegex);
-      let color = isExcluded ? 'gray' : 'white';
-      let outputFile = isExcluded ?
-        this.potExcludeFile :
-        this.potFile;
+      let color = 'white';
+      let outputFile = this.potFile;
 
       let potFile = this._getFileName(outputFile);
       this.ui.writeLine(chalk[color](`Extracting ${file} >>> ${potFile}...`));
 
-      parseJsFile(file, options, isExcluded ? this.excludedGettextItems : this.messageGettextItems);
+      parseJsFile(file, options, this.messageGettextItems);
     });
 
     this.ui.writeLine(chalk.green.bold(`\nExtracted ${files.length} files ✔`));
@@ -407,24 +403,25 @@ EXTRACTING TEMPLATE TRANSLATIONS
     );
 
     files.forEach((file) => {
-      if (file.match(this.skipRegex)) {
+      if (this._shouldSkipFile(file)) {
         this.ui.writeLine(chalk.yellow(`Skipping ${file}...`));
         return;
       }
 
-      let isExcluded = file.match(this.excludeRegex);
-      let color = isExcluded ? 'gray' : 'white';
-      let outputFile = isExcluded ?
-        this.potExcludeFile :
-        this.potFile;
+      let color = 'white';
+      let outputFile = this.potFile;
 
       let potFile = this._getFileName(outputFile);
       this.ui.writeLine(chalk[color](`Extracting ${file} >>> ${potFile}...`));
 
-      parseHbsFile(file, options, isExcluded ? this.excludedGettextItems : this.messageGettextItems);
+      parseHbsFile(file, options, this.messageGettextItems);
     });
 
     this.ui.writeLine(chalk.green.bold(`\nExtracted ${files.length} files ✔`));
+  },
+
+  _shouldSkipFile(file) {
+    return (this.includeRegex && !file.match(this.includeRegex)) || file.match(this.skipRegex);
   },
 
   /**

--- a/node-tests/acceptance/commands/convert-test.js
+++ b/node-tests/acceptance/commands/convert-test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const shell = require('shelljs');
 const rimraf = require('rimraf');
 const Command = require('ember-cli/lib/models/command');
-const MockUI = require('console-ui/mock');
+const MockUI = require('console-ui/mock'); // eslint-disable-line
 const ConvertCommand = require('./../../../lib/commands/convert');
 
 function getOptions(options = {}) {

--- a/node-tests/acceptance/commands/extract-test.js
+++ b/node-tests/acceptance/commands/extract-test.js
@@ -101,4 +101,20 @@ describe('extract command', function() {
     expect(actualFileContent).to.equals(expectedFileContent);
   });
 
+  it('correctly handles --include-patterns & --skip-patterns', async function() {
+    let options = getOptions({
+      extractFrom: './tests',
+      includePatterns: ['dummy/app'],
+      skipPatterns: ['services']
+    });
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    let expectedFileContent = getPoFileContent('./node-tests/fixtures/extract/expected-without-skipped.pot');
+    let actualFileContent = getPoFileContent('./tmp/ember-l10n-tests/messages.pot');
+
+    expect(actualFileContent).to.equals(expectedFileContent);
+  });
+
 });

--- a/node-tests/acceptance/commands/extract-test.js
+++ b/node-tests/acceptance/commands/extract-test.js
@@ -17,7 +17,7 @@ function getOptions(options = {}) {
     package: 'Test App',
     version: '1.0',
     extractFrom: './tests/dummy/app',
-    excludePatterns: [],
+    includePatterns: [],
     skipPatterns: [],
     skipDependencies: [],
     skipAllDependencies: false,

--- a/node-tests/acceptance/commands/extract-test.js
+++ b/node-tests/acceptance/commands/extract-test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const shell = require('shelljs');
 const rimraf = require('rimraf');
 const Command = require('ember-cli/lib/models/command');
-const MockUI = require('console-ui/mock');
+const MockUI = require('console-ui/mock'); //eslint-disable-line
 const ExtractCommand = require('./../../../lib/commands/extract');
 
 function getOptions(options = {}) {

--- a/node-tests/fixtures/extract/expected-without-skipped.pot
+++ b/node-tests/fixtures/extract/expected-without-skipped.pot
@@ -1,0 +1,63 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Test Company
+# This file is distributed under the same license as the Test App package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Test App 1.0\n"
+"Report-Msgid-Bugs-To: test-email@email.com\n"
+"POT-Creation-Date: 2018-08-20 14:57+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tests/dummy/app/templates/application.hbs:24:0
+msgid "Hello world!"
+msgstr ""
+
+#: tests/dummy/app/templates/application.hbs:39:2
+#: tests/dummy/app/templates/application.hbs:50:2
+msgid "You have {{count}} unit in your cart."
+msgid_plural "You have {{count}} units in your cart."
+msgstr[0] ""
+msgstr[1] ""
+
+#: tests/dummy/app/templates/application.hbs:63:0
+msgid "My name is {{name}}."
+msgstr ""
+
+#: tests/dummy/app/templates/application.hbs:71:0
+msgctxt "menu"
+msgid "User"
+msgstr ""
+
+#: tests/dummy/app/templates/application.hbs:89:20
+msgid "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.hbs:2:2
+msgid "This page only contains text for tests"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.hbs:6:2
+msgid ""
+"Multi-line translations\n"
+"work!"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.hbs:13:2
+msgid ""
+"Translations with\n"
+"<strong>tags</strong> and weird indentation\n"
+"works"
+msgstr ""
+
+#: tests/dummy/app/templates/test-page.hbs:19:0
+msgid "en"
+msgstr ""

--- a/node-tests/index.js
+++ b/node-tests/index.js
@@ -5,7 +5,6 @@ const mocha = new Mocha({
   reporter: 'spec'
 });
 
-const arg = process.argv[2];
 const root = 'node-tests/';
 
 function addFiles(mocha, files) {
@@ -16,6 +15,6 @@ addFiles(mocha, '/**/*-test.js');
 
 mocha.run(function(failures) {
   process.on('exit', function() {
-    process.exit(failures);
+    process.exit(failures); // eslint-disable-line
   });
 });

--- a/node-tests/unit/commands/utils/parse-js-test.js
+++ b/node-tests/unit/commands/utils/parse-js-test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
 const { parseJsFile } = require('./../../../../lib/commands/utils/parse-js');
 
-
 describe('parseJsFile util', function() {
 
   it('it correctly parses t method', function() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "ember build",
     "lint:hbs": "ember-template-lint ./addon ./app ./tests/dummy",
-    "lint:js": "eslint ./*.js addon app config lib tests",
+    "lint:js": "eslint .",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each",
@@ -17,7 +17,7 @@
   },
   "repository": "https://github.com/Cropster/ember-l10n",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": ">= 6"
   },
   "author": "Cropster",
   "license": "MIT",


### PR DESCRIPTION
This PR removes the `--exclude-patterns` option from the `ember l10n:extract` command, and instead adds a new `--include-patterns` option to help you manually do the same thing, if necessary.

See #44 for a detailed explanation about the _why_ for this change.