### PR TITLE
Improve convert command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
         'index.js',
         'testem.js',
         'config/**/*.js',
-        'tests/dummy/config/**/*.js'
+        'tests/dummy/config/**/*.js',
+        'lib/**/*.js'
       ],
       excludedFiles: [
         'app/**',

--- a/lib/commands/abstract.js
+++ b/lib/commands/abstract.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 let fs = require('fs');

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 let fs = require('fs');
@@ -152,6 +150,9 @@ CREATING JSON FILE
       // Fix curly single/double quotes, to ensure translations work
       this._fixCurlyQuotes(item);
     });
+
+    // Ensure it is sorted consistently
+
   },
 
   /**

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -153,6 +153,13 @@ CREATING JSON FILE
         return;
       }
 
+      // If the translation is the same as the ID (e.g. for the source language), also remove it
+      // We use the ID by default anyhow, so this will reduce the size of the JSON for the default language
+      if (item.msgid === item.msgstr[0] && (!item.msgid_plural || item.msgid_plural === item.msgstr[1])) {
+        delete namespace[id];
+        return;
+      }
+
       // Remove comments, as we don't need them
       delete item.comments;
 

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -172,6 +172,14 @@ CREATING JSON FILE
       delete json.translations[''][''];
     }
 
+    // Ensure plural form has trailing `;`
+    if (json.headers['plural-forms']) {
+      let pluralForm = json.headers['plural-forms'];
+      if (!pluralForm.endsWith(';')) {
+        json.headers['plural-forms'] = `${pluralForm};`;
+      }
+    }
+
     // Ensure it is sorted consistently (by message id)
     this._sortJSON(json);
 

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -156,8 +156,23 @@ CREATING JSON FILE
       this._fixCurlyQuotes(item);
     });
 
-    // Ensure it is sorted consistently
+    // Ensure it is sorted consistently (by message id)
+    this._sortJSON(json);
+  },
 
+  _sortJSON(json) {
+    let { translations } = json;
+
+    Object.keys(translations).sort((a, b) => a.localeCompare(b)).forEach((namespace) => {
+      let sortedNamespace = {};
+
+      Object.keys(translations[namespace]).sort((a, b) => a.localeCompare(b)).forEach((k) => {
+        sortedNamespace[k] = translations[namespace][k];
+      });
+
+      delete translations[namespace];
+      translations[namespace] = sortedNamespace;
+    });
   },
 
   /**

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -156,6 +156,11 @@ CREATING JSON FILE
       this._fixCurlyQuotes(item);
     });
 
+    // Delete info-item in translations (if it exists)
+    if (json.translations[''] && json.translations['']['']) {
+      delete json.translations[''][''];
+    }
+
     // Ensure it is sorted consistently (by message id)
     this._sortJSON(json);
   },

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -143,10 +143,14 @@ CREATING JSON FILE
    * @private
    */
   _processJSON(json) {
+    let untranslatedItemCount = 0;
+
     traverseJson(json, (item, namespace, id) => {
       // If the item is not translated, remove it
       if (!item.msgstr || !item.msgstr[0]) {
+        untranslatedItemCount++;
         delete namespace[id];
+        return;
       }
 
       // Remove comments, as we don't need them
@@ -163,6 +167,11 @@ CREATING JSON FILE
 
     // Ensure it is sorted consistently (by message id)
     this._sortJSON(json);
+
+    if (untranslatedItemCount > 0) {
+      this.ui.writeLine(chalk.yellow(`${untranslatedItemCount} messages have not been translated - skipping them in the generated JSON file...`));
+      this.ui.writeLine('');
+    }
   },
 
   _sortJSON(json) {

--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -143,7 +143,12 @@ CREATING JSON FILE
    * @private
    */
   _processJSON(json) {
-    traverseJson(json, (item) => {
+    traverseJson(json, (item, namespace, id) => {
+      // If the item is not translated, remove it
+      if (!item.msgstr || !item.msgstr[0]) {
+        delete namespace[id];
+      }
+
       // Remove comments, as we don't need them
       delete item.comments;
 

--- a/lib/commands/extract.js
+++ b/lib/commands/extract.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 const chalk = require('chalk');

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 let chalk = require('chalk');

--- a/lib/commands/sync.js
+++ b/lib/commands/sync.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 let fs = require('fs');

--- a/lib/commands/utils/build-pot-file.js
+++ b/lib/commands/utils/build-pot-file.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 function normalizeMsgId(str) {
   if (!str) {
     return '';

--- a/lib/commands/utils/parse-hbs.js
+++ b/lib/commands/utils/parse-hbs.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const fs = require('fs');
 const { preprocess } = require('@glimmer/syntax');
 

--- a/lib/commands/utils/parse-js.js
+++ b/lib/commands/utils/parse-js.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const fs = require('fs');
 const esprima = require('esprima');
 

--- a/lib/commands/utils/traverse-json.js
+++ b/lib/commands/utils/traverse-json.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 /**
  * This will traverse an l10n-JSON file, and call the callback function for each translation item.
  *

--- a/lib/commands/utils/traverse-json.js
+++ b/lib/commands/utils/traverse-json.js
@@ -17,7 +17,7 @@ function traverseJson(json, callback) {
 
   Object.keys(translations).forEach((namespace) => {
     Object.keys(translations[namespace]).forEach((k) => {
-      callback(translations[namespace][k]);
+      callback(translations[namespace][k], translations[namespace], k);
     });
   });
 }

--- a/lib/commands/utils/validate-json.js
+++ b/lib/commands/utils/validate-json.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 const { validatePlaceholders } = require('./validate/validate-placeholders');
 const { validateTranslatedPlaceholders } = require('./validate/validate-translated-placeholders');
 const { traverseJson } = require('./traverse-json');

--- a/lib/commands/utils/validate/validate-placeholders.js
+++ b/lib/commands/utils/validate/validate-placeholders.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 /**
  * Validate the regular placeholders of an item.
  * This possibly modifies the given validationErrors.

--- a/lib/commands/utils/validate/validate-translated-placeholders.js
+++ b/lib/commands/utils/validate/validate-translated-placeholders.js
@@ -17,6 +17,11 @@ function validateTranslatedPlaceholders({ id, translations }, validationErrors) 
   // This only works in non-plural form, so we assume only one translation
   let [translation] = translations;
 
+  // If the item is not translated at all, ignore it
+  if (!translation) {
+    return;
+  }
+
   // Build an object describing the complex placeholders from the original string
   let placeholders = id.match(pattern) || [];
   if (!placeholders.length) {
@@ -86,5 +91,5 @@ function validateTranslatedPlaceholders({ id, translations }, validationErrors) 
 }
 
 module.exports = {
-    validateTranslatedPlaceholders
+  validateTranslatedPlaceholders
 };

--- a/lib/commands/utils/validate/validate-translated-placeholders.js
+++ b/lib/commands/utils/validate/validate-translated-placeholders.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 /**
  * Validate the translated (complex) placeholders of an item.
  * This mutates the given validationErrors.

--- a/node-tests/acceptance/commands/convert-test.js
+++ b/node-tests/acceptance/commands/convert-test.js
@@ -72,6 +72,18 @@ describe('convert command', function() {
     let expectedFileContent = readJSONFromFile('./node-tests/fixtures/convert/expected.json');
 
     expect(actualFileContent).to.deep.equals(expectedFileContent);
+
+    // Ensure order of props is correct as well
+    let actualNamespaces = Object.keys(actualFileContent.translations);
+    let expectedNamespaces = Object.keys(expectedFileContent.translations);
+
+    expect(actualNamespaces).to.deep.equal(expectedNamespaces, 'namespace sorting is correct');
+
+    actualNamespaces.forEach((namespace) => {
+      let actualItems = Object.keys(actualFileContent.translations[namespace]);
+      let expectedItems = Object.keys(expectedFileContent.translations[namespace]);
+      expect(actualItems).to.deep.equal(expectedItems, `item sorting for namespace ${namespace} is correct`);
+    });
   });
 
 });

--- a/node-tests/acceptance/commands/convert-test.js
+++ b/node-tests/acceptance/commands/convert-test.js
@@ -86,4 +86,37 @@ describe('convert command', function() {
     });
   });
 
+  it('it appends a semicolon to the plural forms if it is missing', async function() {
+    let options = getOptions({});
+
+    // First put the example en.po in the output folder
+    fs.copyFileSync('./node-tests/fixtures/convert/en-plural-form-no-semicolon.po', `${options.convertFrom}/en.po`);
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    let actualFileContent = readJSONFromFile('./tmp/ember-l10n-tests/en.json');
+    let expectedFileContent = {
+      'charset': 'utf-8',
+      'headers': {
+        'content-transfer-encoding': '8bit',
+        'content-type': 'text/plain; charset=UTF-8',
+        'language': 'en',
+        'language-team': 'none',
+        'last-translator': 'Automatically generated',
+        'mime-version': '1.0',
+        'plural-forms': 'nplurals=2; plural=(n != 1);',
+        'po-revision-date': '2018-07-20 08:39+0200',
+        'pot-creation-date': '2018-07-20 08:39+0200',
+        'project-id-version': 'My App 1.0',
+        'report-msgid-bugs-to': 'support@mycompany.com'
+      },
+      'translations': {
+        '': {}
+      }
+    };
+
+    expect(actualFileContent).to.deep.equals(expectedFileContent);
+  });
+
 });

--- a/node-tests/fixtures/convert/en-plural-form-no-semicolon.po
+++ b/node-tests/fixtures/convert/en-plural-form-no-semicolon.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: My App 1.0\n"
+"Report-Msgid-Bugs-To: support@mycompany.com\n"
+"POT-Creation-Date: 2018-07-20 08:39+0200\n"
+"PO-Revision-Date: 2018-07-20 08:39+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+
+
+#: tests/dummy/app/services/l10n.js:7
+msgid "en"
+msgstr "en"

--- a/node-tests/fixtures/convert/en.po
+++ b/node-tests/fixtures/convert/en.po
@@ -19,42 +19,50 @@ msgstr ""
 
 #: tests/dummy/app/services/l10n.js:7 tests/unit/services/l10n-test.js:169
 msgid "en"
-msgstr "en"
+msgstr "Englisch"
 
 #: tests/dummy/app/services/l10n.js:8
 msgid "de"
-msgstr "de"
+msgstr "Deutsch"
 
 #: tests/dummy/app/services/l10n.js:9
 msgid "ko"
-msgstr "ko"
+msgstr "Koreanisch"
 
 #: tests/unit/services/l10n-test.js:145 tests/unit/services/l10n-test.js:203
 #: tests/unit/services/l10n-test.js:214 tests/unit/services/l10n-test.js:224
 #: tests/unit/services/l10n-test.js:235
 msgid "You have {{count}} unit in your cart."
 msgid_plural "You have {{count}} units in your cart."
-msgstr[0] "You have {{count}} unit in your cart."
-msgstr[1] "You have {{count}} units in your cart."
+msgstr[0] "Du hast {{count}} Objekt in deinem Einkaufswagen."
+msgstr[1] "Du hast {{count}} Objekte in deinem Einkaufswagen."
+
+#: tests/unit/services/l10n-test.js:145 tests/unit/services/l10n-test.js:203
+#: tests/unit/services/l10n-test.js:214 tests/unit/services/l10n-test.js:224
+#: tests/unit/services/l10n-test.js:235
+msgid "You have {{count}} unit in your cart. A"
+msgid_plural "You have {{count}} units in your cart. A"
+msgstr[0] "You have {{count}} unit in your cart. A"
+msgstr[1] "You have {{count}} units in your cart. A"
 
 #: tests/unit/services/l10n-test.js:176
 msgid "I'm a {{placeholder}}."
-msgstr "I'm a {{placeholder}}."
+msgstr "Ich bin ein {{placeholder}}."
 
 #: tests/unit/services/l10n-test.js:186
 msgid "STATUS_ACTIVE"
-msgstr "STATUS_ACTIVE"
+msgstr "Aktiv"
 
 #: tests/unit/services/l10n-test.js:185
 msgid "Current status: {{status}}"
-msgstr "Current status: {{status}}"
+msgstr "Derzeitiger Status: {{status}}"
 
 #: tests/unit/services/l10n-test.js:247 tests/unit/services/l10n-test.js:253
 msgctxt "menu"
 msgid "user"
 msgid_plural "users"
-msgstr[0] "user"
-msgstr[1] "users"
+msgstr[0] "Benutzer"
+msgstr[1] "Benuzter"
 
 #: tests/unit/services/l10n-test.js:248
 msgid "\"double quotes\" and 'single quotes'"
@@ -64,24 +72,24 @@ msgstr "“double quotes” and ‘single quotes’"
 msgctxt "menu"
 msgid "You have {{count}} subscription"
 msgid_plural "You have {{count}} subscriptions"
-msgstr[0] "You have {{count}} subscription"
-msgstr[1] "You have {{count}} subscriptions"
+msgstr[0] "Du hast {{count}} Account"
+msgstr[1] "Du hast {{count}} Accounts"
 
 #: tests/unit/services/l10n-test.js:314
 msgid "testing"
-msgstr "testing"
+msgstr "testend"
 
 #: tests/dummy/app/templates/application.hbs:24
 msgid "Hello world!"
-msgstr "Hello world!"
+msgstr "Hallo Welt!"
 
 #: tests/dummy/app/templates/application.hbs:63
 msgid "My name is {{name}}."
-msgstr "My name is {{name}}."
+msgstr "Mein Name ist {{name}}."
 
 #: tests/dummy/app/templates/application.hbs:89
 msgid "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
-msgstr "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+msgstr "Lies mehr im {{linkToGuide 'Guide'}} oder in der {{linkToHelp 'Hilfe'}}."
 
 #: tests/dummy/app/templates/application.hbs:71
 msgctxt "menu"

--- a/node-tests/fixtures/convert/en.po
+++ b/node-tests/fixtures/convert/en.po
@@ -88,5 +88,14 @@ msgctxt "menu"
 msgid "User"
 msgstr "User"
 
+#: tests/dummy/app/templates/application.hbs:90
+msgid "untranslated string"
+msgstr ""
+
+#: tests/dummy/app/templates/application.hbs:90
+msgctxt "menu"
+msgid "untranslated string in context"
+msgstr ""
+
 #~ msgid "asdasd"
 #~ msgstr "asdasd"

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -15,12 +15,6 @@
   },
   "translations": {
     "": {
-      "": {
-        "msgid": "",
-        "msgstr": [
-          "Project-Id-Version: My App 1.0\nReport-Msgid-Bugs-To: support@mycompany.com\nPOT-Creation-Date: 2018-07-20 08:39+0200\nPO-Revision-Date: 2018-07-20 08:39+0200\nLast-Translator: Automatically generated\nLanguage-Team: none\nLanguage: en\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1);\n"
-        ]
-      },
       "\"double quotes\" and 'single quotes'": {
         "msgid": "\"double quotes\" and 'single quotes'",
         "msgstr": [

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -21,44 +21,6 @@
           "Project-Id-Version: My App 1.0\nReport-Msgid-Bugs-To: support@mycompany.com\nPOT-Creation-Date: 2018-07-20 08:39+0200\nPO-Revision-Date: 2018-07-20 08:39+0200\nLast-Translator: Automatically generated\nLanguage-Team: none\nLanguage: en\nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nPlural-Forms: nplurals=2; plural=(n != 1);\n"
         ]
       },
-      "en": {
-        "msgid": "en",
-        "msgstr": [
-          "en"
-        ]
-      },
-      "de": {
-        "msgid": "de",
-        "msgstr": [
-          "de"
-        ]
-      },
-      "ko": {
-        "msgid": "ko",
-        "msgstr": [
-          "ko"
-        ]
-      },
-      "You have {{count}} unit in your cart.": {
-        "msgid": "You have {{count}} unit in your cart.",
-        "msgid_plural": "You have {{count}} units in your cart.",
-        "msgstr": [
-          "You have {{count}} unit in your cart.",
-          "You have {{count}} units in your cart."
-        ]
-      },
-      "I'm a {{placeholder}}.": {
-        "msgid": "I'm a {{placeholder}}.",
-        "msgstr": [
-          "I'm a {{placeholder}}."
-        ]
-      },
-      "STATUS_ACTIVE": {
-        "msgid": "STATUS_ACTIVE",
-        "msgstr": [
-          "STATUS_ACTIVE"
-        ]
-      },
       "\"double quotes\" and 'single quotes'": {
         "msgid": "\"double quotes\" and 'single quotes'",
         "msgstr": [
@@ -71,16 +33,34 @@
           "Current status: {{status}}"
         ]
       },
-      "testing": {
-        "msgid": "testing",
+      "de": {
+        "msgid": "de",
         "msgstr": [
-          "testing"
+          "de"
+        ]
+      },
+      "en": {
+        "msgid": "en",
+        "msgstr": [
+          "en"
         ]
       },
       "Hello world!": {
         "msgid": "Hello world!",
         "msgstr": [
           "Hello world!"
+        ]
+      },
+      "I'm a {{placeholder}}.": {
+        "msgid": "I'm a {{placeholder}}.",
+        "msgstr": [
+          "I'm a {{placeholder}}."
+        ]
+      },
+      "ko": {
+        "msgid": "ko",
+        "msgstr": [
+          "ko"
         ]
       },
       "My name is {{name}}.": {
@@ -94,6 +74,26 @@
         "msgstr": [
           "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
         ]
+      },
+      "STATUS_ACTIVE": {
+        "msgid": "STATUS_ACTIVE",
+        "msgstr": [
+          "STATUS_ACTIVE"
+        ]
+      },
+      "testing": {
+        "msgid": "testing",
+        "msgstr": [
+          "testing"
+        ]
+      },
+      "You have {{count}} unit in your cart.": {
+        "msgid": "You have {{count}} unit in your cart.",
+        "msgid_plural": "You have {{count}} units in your cart.",
+        "msgstr": [
+          "You have {{count}} unit in your cart.",
+          "You have {{count}} units in your cart."
+        ]
       }
     },
     "menu": {
@@ -106,6 +106,13 @@
           "users"
         ]
       },
+      "User": {
+        "msgid": "User",
+        "msgctxt": "menu",
+        "msgstr": [
+          "User"
+        ]
+      },
       "You have {{count}} subscription": {
         "msgid": "You have {{count}} subscription",
         "msgctxt": "menu",
@@ -113,13 +120,6 @@
         "msgstr": [
           "You have {{count}} subscription",
           "You have {{count}} subscriptions"
-        ]
-      },
-      "User": {
-        "msgid": "User",
-        "msgctxt": "menu",
-        "msgstr": [
-          "User"
         ]
       }
     }

--- a/node-tests/fixtures/convert/expected.json
+++ b/node-tests/fixtures/convert/expected.json
@@ -24,69 +24,69 @@
       "Current status: {{status}}": {
         "msgid": "Current status: {{status}}",
         "msgstr": [
-          "Current status: {{status}}"
+          "Derzeitiger Status: {{status}}"
         ]
       },
       "de": {
         "msgid": "de",
         "msgstr": [
-          "de"
+          "Deutsch"
         ]
       },
       "en": {
         "msgid": "en",
         "msgstr": [
-          "en"
+          "Englisch"
         ]
       },
       "Hello world!": {
         "msgid": "Hello world!",
         "msgstr": [
-          "Hello world!"
+          "Hallo Welt!"
         ]
       },
       "I'm a {{placeholder}}.": {
         "msgid": "I'm a {{placeholder}}.",
         "msgstr": [
-          "I'm a {{placeholder}}."
+          "Ich bin ein {{placeholder}}."
         ]
       },
       "ko": {
         "msgid": "ko",
         "msgstr": [
-          "ko"
+          "Koreanisch"
         ]
       },
       "My name is {{name}}.": {
         "msgid": "My name is {{name}}.",
         "msgstr": [
-          "My name is {{name}}."
+          "Mein Name ist {{name}}."
         ]
       },
       "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.": {
         "msgid": "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}.",
         "msgstr": [
-          "Read more in our {{linkToGuide 'guide'}} or {{linkToHelp 'help'}}."
+          "Lies mehr im {{linkToGuide 'Guide'}} oder in der {{linkToHelp 'Hilfe'}}."
         ]
       },
       "STATUS_ACTIVE": {
         "msgid": "STATUS_ACTIVE",
         "msgstr": [
-          "STATUS_ACTIVE"
+          "Aktiv"
         ]
       },
       "testing": {
         "msgid": "testing",
         "msgstr": [
-          "testing"
+          "testend"
         ]
       },
       "You have {{count}} unit in your cart.": {
         "msgid": "You have {{count}} unit in your cart.",
         "msgid_plural": "You have {{count}} units in your cart.",
         "msgstr": [
-          "You have {{count}} unit in your cart.",
-          "You have {{count}} units in your cart."
+          "Du hast {{count}} Objekt in deinem Einkaufswagen.",
+          "Du hast {{count}} Objekte in deinem Einkaufswagen."
         ]
       }
     },
@@ -96,15 +96,8 @@
         "msgctxt": "menu",
         "msgid_plural": "users",
         "msgstr": [
-          "user",
-          "users"
-        ]
-      },
-      "User": {
-        "msgid": "User",
-        "msgctxt": "menu",
-        "msgstr": [
-          "User"
+          "Benutzer",
+          "Benuzter"
         ]
       },
       "You have {{count}} subscription": {
@@ -112,8 +105,8 @@
         "msgctxt": "menu",
         "msgid_plural": "You have {{count}} subscriptions",
         "msgstr": [
-          "You have {{count}} subscription",
-          "You have {{count}} subscriptions"
+          "Du hast {{count}} Account",
+          "Du hast {{count}} Accounts"
         ]
       }
     }

--- a/node-tests/unit/commands/utils/parse-hbs-test.js
+++ b/node-tests/unit/commands/utils/parse-hbs-test.js
@@ -1,7 +1,6 @@
 const { expect } = require('chai');
 const { parseHbsFile } = require('./../../../../lib/commands/utils/parse-hbs');
 
-
 describe('parseHbsFile util', function() {
 
   it('it correctly parses t helper', function() {

--- a/node-tests/unit/commands/utils/validate/validate-placeholders-test.js
+++ b/node-tests/unit/commands/utils/validate/validate-placeholders-test.js
@@ -1,0 +1,98 @@
+const { expect } = require('chai');
+const { validatePlaceholders } = require('./../../../../../lib/commands/utils/validate/validate-placeholders');
+
+
+describe('validatePlaceholders util', function() {
+  it('it works for empty id', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: '',
+      translations: []
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works without placeholder', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test',
+      translations: ['My test']
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with translated placeholder', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val}}',
+      translations: ['My test {{val}}']
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with wrong placeholder', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val}}',
+      translations: ['My test {{val2}}']
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [
+      {
+        'id': 'My test {{val}}',
+        'level': 'ERROR',
+        'message': 'The placeholder "{{val2}}" seems to be wrongly translated. Allowed: {{val}}',
+        'translation': 'My test {{val2}}'
+      }
+    ];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with multiple placeholders', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val}} {{val2}} {{val3}}',
+      translations: ['My {{val3}} test {{val4}} {{val5}}']
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [
+      {
+        'id': 'My test {{val}} {{val2}} {{val3}}',
+        'level': 'ERROR',
+        'message': 'The placeholder "{{val4}}" seems to be wrongly translated. Allowed: {{val}}, {{val2}}, {{val3}}',
+        'translation': 'My {{val3}} test {{val4}} {{val5}}'
+      }
+    ];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with wrong Asian-character placeholder', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val}}',
+      translations: ['My test {{该}}']
+    };
+    validatePlaceholders(gettextItem, validationErrors);
+
+    let expected = [
+      {
+        'id': 'My test {{val}}',
+        'level': 'ERROR',
+        'message': 'The placeholder "{{该}}" seems to be wrongly translated. Allowed: {{val}}',
+        'translation': 'My test {{该}}'
+      }
+    ];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+});

--- a/node-tests/unit/commands/utils/validate/validate-translated-placeholders-test.js
+++ b/node-tests/unit/commands/utils/validate/validate-translated-placeholders-test.js
@@ -1,0 +1,103 @@
+const { expect } = require('chai');
+const { validateTranslatedPlaceholders } = require('./../../../../../lib/commands/utils/validate/validate-translated-placeholders');
+
+
+describe('validateTranslatedPlaceholders util', function() {
+  it('it works for empty id', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: '',
+      translations: []
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works without translated placeholders', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val}}',
+      translations: ['My test {{val}}']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it ignores missing translations for translated placeholders', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val "test"}}',
+      translations: ['']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with correct translated placeholders for default language', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val "test"}}',
+      translations: ['My test {{val "test"}}']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with correct translated placeholders for other language', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val "test"}}',
+      translations: ['Mein test {{val "Test"}}']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with incorrect translated placeholders for other language', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val "test"}}',
+      translations: ['Mein test {{val "test"}}']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [
+      {
+        'id': 'My test {{val "test"}}',
+        'level': 'WARNING',
+        'message': 'The content "test" for complex placeholder "val" is not translated',
+        'translation': 'Mein test {{val "test"}}'
+      }
+    ];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+
+  it('it works with changed placeholder names', function() {
+    let validationErrors = [];
+    let gettextItem = {
+      id: 'My test {{val "test"}}',
+      translations: ['Mein test {{val2 "test"}}']
+    };
+    validateTranslatedPlaceholders(gettextItem, validationErrors);
+
+    let expected = [
+      {
+        'id': 'My test {{val "test"}}',
+        'level': 'ERROR',
+        'message': 'The complex placeholder "val" is not correctly translated',
+        'translation': 'Mein test {{val2 "test"}}'
+      }
+    ];
+    expect(validationErrors).to.deep.equal(expected);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ember-get-config": "^0.2.4",
     "esprima": "^4.0.1",
     "gettext-parser": "^3.0.0",
+    "inquirer": "^6.2.1",
     "shelljs": "^0.8.2"
   },
   "ember-addon": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,6 +844,11 @@ ansi-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
   integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
 
+ansi-regex@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
+  integrity sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w==
+
 ansi-styles@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.1.0.tgz#eaecbf66cd706882760b2f4691582b8f55d7a7de"
@@ -5883,6 +5888,25 @@ inquirer@^6.1.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+inquirer@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
+  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
+    string-width "^2.1.0"
+    strip-ansi "^5.0.0"
+    through "^2.3.6"
+
 interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
@@ -9727,6 +9751,13 @@ strip-ansi@^4.0.0:
   integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
   dependencies:
     ansi-regex "^3.0.0"
+
+strip-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.0.0.tgz#f78f68b5d0866c20b2c9b8c61b5298508dc8756f"
+  integrity sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==
+  dependencies:
+    ansi-regex "^4.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR makes some improvements to the `ember l10n:convert` command:

* Improve validation: It will skip untranslated items for validation, making the output more consise
* It will show the number of untranslated items
* Add tests for validation
* Ensure untranslated items are removed from the generated JSON to reduce the JSON size
* Ensure unchanged items are removed from the generated JSON to reduce the JSON size (for the default language)
* Ensure the order of items in the generated JSON is always consistent by sorting it by message id
* Remove the header item from the translations (the `translations['']['']` item)