### PR TITLE
Use @babel/parser instead of esprima for JS extraction

### DIFF
--- a/lib/commands/utils/parse-js.js
+++ b/lib/commands/utils/parse-js.js
@@ -1,9 +1,6 @@
 const fs = require('fs');
-const esprima = require('esprima');
-
-function filterAstItemsByType(allItems, types) {
-  return allItems.filter((item) => types.includes(item.type));
-}
+const babelParser = require('@babel/parser');
+const { visit } = require('ast-types');
 
 function filterAstItemsByPropertyName(allItems, propertyNames) {
   return allItems.filter(
@@ -39,9 +36,7 @@ function getItemText(item, fileName) {
 }
 
 function parseJs(fileName, astItems, gettextItems) {
-  let filteredItems = filterAstItemsByType(astItems, ['CallExpression']);
-
-  filterAstItemsByPropertyName(filteredItems, ['t']).forEach((item) => {
+  filterAstItemsByPropertyName(astItems, ['t']).forEach((item) => {
     if (item.arguments.length < 1) {
       throw new Error(
         `t() invocation does not seem to have proper arguments: ${fileName}:${
@@ -63,7 +58,7 @@ function parseJs(fileName, astItems, gettextItems) {
     });
   });
 
-  filterAstItemsByPropertyName(filteredItems, ['pt']).forEach((item) => {
+  filterAstItemsByPropertyName(astItems, ['pt']).forEach((item) => {
     if (item.arguments.length < 2) {
       throw new Error(
         `pt() invocation does not seem to have proper arguments: ${fileName}:${
@@ -87,7 +82,7 @@ function parseJs(fileName, astItems, gettextItems) {
     });
   });
 
-  filterAstItemsByPropertyName(filteredItems, ['n']).forEach((item) => {
+  filterAstItemsByPropertyName(astItems, ['n']).forEach((item) => {
     if (item.arguments.length < 3) {
       throw new Error(
         `n() invocation does not seem to have proper arguments: ${fileName}:${
@@ -111,7 +106,7 @@ function parseJs(fileName, astItems, gettextItems) {
     });
   });
 
-  filterAstItemsByPropertyName(filteredItems, ['pn']).forEach((item) => {
+  filterAstItemsByPropertyName(astItems, ['pn']).forEach((item) => {
     if (item.arguments.length < 4) {
       throw new Error(
         `pn() invocation does not seem to have proper arguments: ${fileName}:${
@@ -146,9 +141,28 @@ function parseJsFile(file, options, gettextItems) {
   let data = fs.readFileSync(file, encoding);
   let astItems = [];
 
-  let esprimaOptions = { range: false, loc: true };
-  esprima.parseModule(data, esprimaOptions, (node) => {
-    astItems.push(node);
+  let parserOptions = {
+    range: false,
+    loc: true,
+    sourceType: 'module',
+    // See: https://babeljs.io/docs/en/babel-parser
+    plugins: [
+      'classProperties',
+      'asyncGenerators',
+      'dynamicImport',
+      'decorators-legacy',
+      'typescript',
+      'objectRestSpread'
+    ]
+  };
+  let ast = babelParser.parse(data, parserOptions);
+
+  visit(ast, {
+    visitCallExpression(path) {
+      let { node } = path;
+      astItems.push(node);
+      this.traverse(path);
+    }
   });
 
   return parseJs(file, astItems, gettextItems);

--- a/node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs
+++ b/node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs
@@ -1,0 +1,6 @@
+<MyComponent
+  html-prop={{t "other test content"}}
+  @prop={{t 'test content'}}
+>
+  {{t 'test inner content'}}
+</MyComponent>

--- a/node-tests/fixtures/parse-js/native-js-class-with-decorators.js
+++ b/node-tests/fixtures/parse-js/native-js-class-with-decorators.js
@@ -1,0 +1,20 @@
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
+import { tagName } from '@ember-decorators/component';
+
+@tagName('span')
+export default class MyClass {
+  @service l10n;
+
+  testFunc() {
+    return this.l10n.t('test string');
+  }
+
+  @computed()
+  get myProp() {
+    return this.l10n.t('other test string - this@my-domain.com');
+  }
+
+  @reads('l10n.other') readsProp;
+}

--- a/node-tests/fixtures/parse-js/native-js-class.js
+++ b/node-tests/fixtures/parse-js/native-js-class.js
@@ -1,0 +1,5 @@
+export default class MyClass {
+  testFunc() {
+    return this.l10n.t('test string');
+  }
+}

--- a/node-tests/fixtures/parse-js/typescript.ts
+++ b/node-tests/fixtures/parse-js/typescript.ts
@@ -1,0 +1,13 @@
+export default class TypescriptTestClass {
+  l10n = L10n;
+
+  greet(message: string) {
+    return this.l10n.t('test content {{message}}', { message });
+  }
+}
+
+const L10n = {
+  t(message: string, placeholder: object) {
+    return message;
+  }
+};

--- a/node-tests/unit/commands/utils/parse-hbs-test.js
+++ b/node-tests/unit/commands/utils/parse-hbs-test.js
@@ -415,6 +415,45 @@ describe('parseHbsFile util', function() {
     expect(gettextItems).to.deep.equal([]);
   });
 
+  it('it correctly parses angle bracket component invocation', function() {
+    let options = { fromCode: 'UTF-8' };
+
+    let gettextItems = [];
+    let fileName =
+      './node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs';
+    parseHbsFile(fileName, options, gettextItems);
+
+    expect(gettextItems).to.deep.equal([
+      {
+        loc: {
+          column: 2,
+          fileName:
+            './node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs',
+          line: 5
+        },
+        messageId: 'test inner content'
+      },
+      {
+        loc: {
+          column: 12,
+          fileName:
+            './node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs',
+          line: 2
+        },
+        messageId: 'other test content'
+      },
+      {
+        loc: {
+          column: 8,
+          fileName:
+            './node-tests/fixtures/parse-hbs/angle-bracket-invocation.hbs',
+          line: 3
+        },
+        messageId: 'test content'
+      }
+    ]);
+  });
+
   it('it throws when not using enough arguments for t helper', function() {
     let options = { fromCode: 'UTF-8' };
 

--- a/node-tests/unit/commands/utils/parse-js-test.js
+++ b/node-tests/unit/commands/utils/parse-js-test.js
@@ -140,6 +140,36 @@ with new line`
     ]);
   });
 
+  it('it correctly parses a native JS class with decorators', function() {
+    let options = { fromCode: 'UTF-8' };
+
+    let gettextItems = [];
+    let fileName =
+      './node-tests/fixtures/parse-js/native-js-class-with-decorators.js';
+    parseJsFile(fileName, options, gettextItems);
+
+    expect(gettextItems).to.deep.equal([
+      {
+        loc: {
+          column: 11,
+          fileName:
+            './node-tests/fixtures/parse-js/native-js-class-with-decorators.js',
+          line: 11
+        },
+        messageId: 'test string'
+      },
+      {
+        loc: {
+          column: 11,
+          fileName:
+            './node-tests/fixtures/parse-js/native-js-class-with-decorators.js',
+          line: 16
+        },
+        messageId: 'other test string - this@my-domain.com'
+      }
+    ]);
+  });
+
   it('it throws on template literals with placeholder', function() {
     let options = { fromCode: 'UTF-8' };
 

--- a/node-tests/unit/commands/utils/parse-js-test.js
+++ b/node-tests/unit/commands/utils/parse-js-test.js
@@ -121,6 +121,25 @@ with new line`
     ]);
   });
 
+  it('it correctly parses a native JS class', function() {
+    let options = { fromCode: 'UTF-8' };
+
+    let gettextItems = [];
+    let fileName = './node-tests/fixtures/parse-js/native-js-class.js';
+    parseJsFile(fileName, options, gettextItems);
+
+    expect(gettextItems).to.deep.equal([
+      {
+        loc: {
+          column: 11,
+          fileName: './node-tests/fixtures/parse-js/native-js-class.js',
+          line: 3
+        },
+        messageId: 'test string'
+      }
+    ]);
+  });
+
   it('it throws on template literals with placeholder', function() {
     let options = { fromCode: 'UTF-8' };
 

--- a/node-tests/unit/commands/utils/parse-js-test.js
+++ b/node-tests/unit/commands/utils/parse-js-test.js
@@ -170,6 +170,25 @@ with new line`
     ]);
   });
 
+  it('it correctly parses a typescript file', function() {
+    let options = { fromCode: 'UTF-8' };
+
+    let gettextItems = [];
+    let fileName = './node-tests/fixtures/parse-js/typescript.ts';
+    parseJsFile(fileName, options, gettextItems);
+
+    expect(gettextItems).to.deep.equal([
+      {
+        loc: {
+          column: 11,
+          fileName: './node-tests/fixtures/parse-js/typescript.ts',
+          line: 5
+        },
+        messageId: 'test content {{message}}'
+      }
+    ]);
+  });
+
   it('it throws on template literals with placeholder', function() {
     let options = { fromCode: 'UTF-8' };
 

--- a/package.json
+++ b/package.json
@@ -72,12 +72,13 @@
     "po"
   ],
   "dependencies": {
+    "@babel/parser": "^7.5.5",
     "@glimmer/syntax": "^0.38.0",
+    "ast-types": "^0.13.2",
     "chalk": "^2.4.1",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-get-config": "^0.2.4",
-    "esprima": "^4.0.1",
     "gettext-parser": "^3.0.0",
     "inquirer": "^6.2.1",
     "shelljs": "^0.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,6 +1246,11 @@ ast-types@0.9.6:
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
   integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
 
+ast-types@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.2.tgz#df39b677a911a83f3a049644fb74fdded23cea48"
+  integrity sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -4620,11 +4625,6 @@ esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
   integrity sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==
-
-esprima@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esprima@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR starts using @babel/parser instead of esprima to do the JS extraction when running `ember l10n:extract`. This parser allows to to parse experimental features, which unlocks:

* extracting from code using decorators (making this compatible with Ember Octane)
* extracting from TypeScript files (fixing #54)

It also adds tests to ensure these variants work.