### PR TITLE
Ensure it works with Fastboot

### DIFF
--- a/addon/components/get-text.js
+++ b/addon/components/get-text.js
@@ -1,5 +1,5 @@
 import { typeOf, isEmpty } from '@ember/utils';
-import { get } from '@ember/object';
+import { get, computed } from '@ember/object';
 import Component from '@ember/component';
 import layout from '../templates/get-text';
 
@@ -66,21 +66,7 @@ export default Component.extend({
    * @type {Array}
    * @public
    */
-  messageParts: null, // lazy initialized!
-
-  // -------------------------------------------------------------------------
-  // Methods
-
-  /**
-   * Parses message id and splits it
-   * up into corresponding parts.
-   *
-   * @method didReceiveAttrs
-   * @return {Void}
-   * @public
-   */
-  didReceiveAttrs() {
-    this._super(...arguments);
+  messageParts: computed('message', function() {
     let message = get(this, 'message');
 
     if (!message) {
@@ -136,7 +122,6 @@ export default Component.extend({
       });
     }
 
-    // provide parts for template
-    this.set('messageParts', parts);
-  }
+    return parts;
+  })
 });

--- a/addon/utils/fetch-json-file.js
+++ b/addon/utils/fetch-json-file.js
@@ -1,0 +1,19 @@
+import { Promise } from 'rsvp';
+
+export function fetchJsonFile(fileName) {
+  return new Promise((resolve, reject) => {
+    let request = new XMLHttpRequest();
+    request.open('GET', fileName);
+    request.addEventListener('load', function() {
+      try {
+        let { responseText } = this;
+        let json = JSON.parse(responseText);
+        resolve(json);
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.addEventListener('error', reject);
+    request.send();
+  });
+}

--- a/addon/utils/get-locale-asset-map.js
+++ b/addon/utils/get-locale-asset-map.js
@@ -1,0 +1,22 @@
+import require from 'require';
+import { assert } from '@ember/debug';
+
+export function getLocaleAssetMap() {
+  // FastBoot cannot read from document, so we require a (specifically built) file in that scenario
+  if (typeof FastBoot !== 'undefined') {
+    let assetMap = require('ember-l10n/fastboot-locale-asset-map');
+    return assetMap.default;
+  }
+
+  let metaTag = document.querySelector(
+    "meta[name='ember-l10n:localeAssetMap']"
+  );
+  if (!metaTag || !metaTag.content) {
+    // eslint-disable-next-line no-console
+    assert('<meta name="ember-l10n:localeAssetMap"> tag is missing.', false);
+    return {};
+  }
+
+  let assetMapString = metaTag.content;
+  return JSON.parse(decodeURIComponent(assetMapString));
+}

--- a/tests/dummy/app/services/l10n.js
+++ b/tests/dummy/app/services/l10n.js
@@ -2,7 +2,7 @@ import L10n from 'ember-l10n/services/l10n';
 import { computed } from '@ember/object';
 
 export default L10n.extend({
-  availableLocales: computed('locale', function() {
+  availableLocales: computed(function() {
     return {
       en: this.t('en'),
       de: this.t('de'),


### PR DESCRIPTION
This PR restores FastBoot compatibility.
It is heavily inspired by https://github.com/adopted-ember-addons/ember-cli-ifa/pull/57/files.

There are basically two main issues that need to be worked around for FastBoot:

1. We cannot load the asset map via `document.querySelector(...)`, as `document` is not available in Node
2. We cannot load the locale files (e.g. `en.json`) via XMLHttpRequest, as that is not available in Node

For 1.), I used the same approach as the one in the references PR to ember-cli-ifa, to build a custom module for Node which can be requested in FastBoot environment (this is encapsulated in the new `utils/get-locale-asset-map.js` file).

For 2.), we embed the actual locale file content in the asset map, instead of the path to the asset map, for the FastBoot module. This way, we avoid needing to make any Ajax requests in FastBoot environment.

FastBoot will also generate a `package.json` file in the output, which needs to be excluded from fingerprinting. This PR will automatically adjust the fingerprinting options to work with ember-l10n now, including adding `json` to `fingerprint.extensions` for you. The user is informed about any changes made to the configuration in the console, e.g.:

```
ember-l10n automatically adjusted the fingerprinting settings to work properly:
* added 'json' to fingerprint.extensions
* added 'package.json' to fingerprint.exclude
```

Note that it does not actually add FastBoot as a dev dependency, and does not add any FastBoot tests for now. I did install FastBoot locally and tried it, to ensure it works as expected (which it did for me). 

Fixes #59 