### PR TITLE
Ensure ember-l10n works with Prember

### DIFF
--- a/lib/utils/create-fastboot-asset-map.js
+++ b/lib/utils/create-fastboot-asset-map.js
@@ -1,0 +1,99 @@
+const Plugin = require('broccoli-plugin');
+const path = require('path');
+
+class CreateEmberL10nFastBootAssetMap extends Plugin {
+  constructor(
+    inputNode,
+    { localeAssetDirectoryPath, fastbootAssetMapModulePath }
+  ) {
+    super([inputNode], {});
+    // This is used to pick the correct files that need to go into the document (e.g. assets/locales)
+    this.localeAssetDirectoryPath = localeAssetDirectoryPath;
+    // This is the filename of the asset map module to be generated (ember-l10n/fastboot-locale-asset-map.js)
+    this.fastbootAssetMapModulePath = fastbootAssetMapModulePath;
+  }
+
+  build() {
+    // We only support passing in one input path (for simplicity)
+    this.inputPath = this.inputPaths[0];
+
+    this.localeAssetMap = {};
+    // This adds locale file content to this.localeAssetMap recursively
+    this.parseNode(this.inputPath);
+
+    this.createFastBootAssetMapModule();
+  }
+
+  parseNode(inputPath) {
+    let stat = this.input.statSync(inputPath);
+
+    if (stat.isFile()) {
+      this.parseFile(inputPath);
+    } else {
+      this.parseDirectory(inputPath);
+    }
+  }
+
+  parseDirectory(inputPath) {
+    let outputPath = this._getOutputPath(inputPath);
+    if (!this.output.existsSync(outputPath)) {
+      this.output.mkdirSync(outputPath);
+    }
+
+    let files = this.input.readdirSync(inputPath);
+    files.forEach((file) => this.parseNode(path.join(inputPath, file)));
+  }
+
+  parseFile(inputPath) {
+    let content = this.input.readFileSync(inputPath);
+    let outputPath = this._getOutputPath(inputPath);
+
+    let dir = path.dirname(outputPath);
+    let isLocaleFile = dir === this.localeAssetDirectoryPath;
+
+    if (isLocaleFile) {
+      this._addToLocaleAssetMap(inputPath, outputPath);
+    }
+
+    // Ensure file remains in tree
+    this.output.writeFileSync(outputPath, content);
+  }
+
+  createFastBootAssetMapModule() {
+    let fastbootAssetMapModuleDir = path.dirname(
+      this.fastbootAssetMapModulePath
+    );
+    if (!this.output.existsSync(fastbootAssetMapModuleDir)) {
+      this.output.mkdirSync(fastbootAssetMapModuleDir);
+    }
+
+    this.output.writeFileSync(
+      this.fastbootAssetMapModulePath,
+      `define('ember-l10n/fastboot-locale-asset-map', [], function () {
+          return {
+            'default': ${JSON.stringify(this.localeAssetMap)},
+            __esModule: true,
+          };
+        });`
+    );
+  }
+
+  _getOutputPath(inputPath) {
+    return path.relative(this.inputPath, inputPath);
+  }
+
+  _addToLocaleAssetMap(inputPath, outputPath) {
+    let fileName = path.basename(outputPath, '.json');
+
+    // Extract locale without fingerprint
+    // This works e.g. for 'en', as well as for 'en-XXXXXXXXXXX'
+    let [localeName] = fileName.split('-');
+
+    this.localeAssetMap[localeName] = this.input.readFileSync(
+      inputPath,
+      'utf-8'
+    );
+  }
+}
+
+module.exports = CreateEmberL10nFastBootAssetMap;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@babel/parser": "^7.5.5",
     "@glimmer/syntax": "^0.47.4",
     "ast-types": "^0.13.2",
+    "broccoli-plugin": "^3.1.0",
     "chalk": "^3.0.0",
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^4.2.2",
@@ -82,7 +83,10 @@
     "shelljs": "^0.8.2"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "ember-cli-uglify"
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
[Prember](https://github.com/ef4/prember) can be used to built static pages with Ember & FastBoot. 

Prember will pre-render pages before the `postBuild()` hook is fired, leading to issues with the way we generate the manifest for FastBoot.
Instead, we now generate the asset map via a Broccoli Plugin (in `postprocessTree`), which works as expected in both regular FastBoot as well as in Prember.

We also need to make sure this addon runs before ember-cli-uglify, as otherwise the `postprocessTree` hooks might conflict.

All changes are made under the assumption that everything works the same way as before for apps without FastBoot/Prember.

I have tested this in an app with FastBoot only, in an app with FastBoot + Prember, and in an app without FastBoot at all, and it worked as expected. It should also not have any effect on build time in apps without FastBoot (as the Plugin doesn't even run then).