### PR TITLE
Bump @glimmer/syntax from 0.47.4 to 0.56.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   ],
   "dependencies": {
     "@babel/parser": "^7.5.5",
-    "@glimmer/syntax": "^0.47.4",
+    "@glimmer/syntax": "^0.56.0",
     "ast-types": "^0.13.2",
     "broccoli-plugin": "^3.1.0",
     "chalk": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,15 +816,20 @@
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
   integrity sha1-c7/Upu5BSKgL8JLopdKbysnUzn4=
 
+"@glimmer/env@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
 "@glimmer/interfaces@^0.41.4":
   version "0.41.4"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"
   integrity sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==
 
-"@glimmer/interfaces@^0.47.4":
-  version "0.47.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.47.4.tgz#17772fae66571b606f9fa26d733d7211960a2560"
-  integrity sha512-Wbv6954fIOy1aWHh2IdneBmIGrGysyu+ZWrmAiuMQC92uf57a9AXFJW0DFY+X6gd8Biaw/Nx8EHE0bNeMYCp9Q==
+"@glimmer/interfaces@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.56.0.tgz#88fbbfb31076c39de4b87af12151c2f6b2aec75c"
+  integrity sha512-MXWkPg8/EECK0pkjCmDb6BTpCBQT83S8R5qKHSZ6yPJmd6AWUunfT/CoHM6faH5yHW4ya7ckM1ZfrHnU5eda4Q==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -845,14 +850,14 @@
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.7"
 
-"@glimmer/syntax@^0.47.4":
-  version "0.47.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.47.4.tgz#827f63a9c5f14a8329ff26c1e1f6ad211683690d"
-  integrity sha512-GCqoKyU11+cD9jL1J6AlSgKn1/rFUt/Wc3pgf/AE7uxza00OOYDEbqfpzOdv9sF727aqKdy9qp3a9O54IcevuA==
+"@glimmer/syntax@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.56.0.tgz#9f7673bdf94637e8652a942a42c96d67fcce9523"
+  integrity sha512-bh0pYOIRKABm6hy2B0QDL1+iJHafDj+lwaLQGtuoDBd2rfbJdmeOfGuKPjU51gQ7tllt/6lOdkQQG4yuO2CNRQ==
   dependencies:
-    "@glimmer/interfaces" "^0.47.4"
-    "@glimmer/util" "^0.47.4"
-    handlebars "^4.5.1"
+    "@glimmer/interfaces" "^0.56.0"
+    "@glimmer/util" "^0.56.0"
+    handlebars "^4.7.4"
     simple-html-tokenizer "^0.5.9"
 
 "@glimmer/util@^0.41.4":
@@ -860,11 +865,13 @@
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.4.tgz#508fd82ca40305416e130f0da7b537295ded7989"
   integrity sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==
 
-"@glimmer/util@^0.47.4":
-  version "0.47.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.47.4.tgz#de6061d30f03ca09950208f6de7b529efc8fb539"
-  integrity sha512-uGcUjDtcy/CTSKMYuIpmvZfv4busDcPbx6X+AnWkaTIonvp0z8HKpZ5QYrulR9Gcbbtb+noCTmMr2qa7AEyA4Q==
+"@glimmer/util@^0.56.0":
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.56.0.tgz#8bce5676c8ac9b9389a736505a57925f7b55d1af"
+  integrity sha512-3TmGZIe5jTtHbjjTV7mwr71M47c+Y1njm3QrJ8Jq4KzD2udryiQkj44Aki+RFlpjZxBRTWWHHInurb6niPr/cg==
   dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "^0.56.0"
     "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/wire-format@^0.41.4":
@@ -5708,7 +5715,7 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.5.1:
+handlebars@^4.0.11, handlebars@^4.0.13, handlebars@^4.0.4, handlebars@^4.7.4:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==


### PR DESCRIPTION
To get the newest Glimmer syntax when parsing hbs files.