### PR TITLE
Update parsing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "po"
   ],
   "dependencies": {
-    "@babel/parser": "^7.5.5",
+    "@babel/parser": "^7.12.3",
     "@glimmer/syntax": "^0.56.0",
     "ast-types": "^0.13.2",
     "broccoli-plugin": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   ],
   "dependencies": {
     "@babel/parser": "^7.12.3",
-    "@glimmer/syntax": "^0.56.0",
+    "@glimmer/syntax": "^0.62.3",
     "ast-types": "^0.14.2",
     "broccoli-plugin": "^4.0.3",
     "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@babel/parser": "^7.12.3",
     "@glimmer/syntax": "^0.56.0",
-    "ast-types": "^0.13.2",
+    "ast-types": "^0.14.2",
     "broccoli-plugin": "^4.0.3",
     "chalk": "^4.1.0",
     "ember-cli-babel": "^7.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,17 +1023,17 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
+"@glimmer/interfaces@0.62.3":
+  version "0.62.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.62.3.tgz#8ad314d66d1a43197663509806e1cc2088db6741"
+  integrity sha512-bhbKs5vfys4mo+LRxcA4bfMl2zGn+43et4uAzsYppuNPSkP7rwdPD+mLXTYQRkTm0G5K4SnyxDPxMsWCWUNuTw==
+  dependencies:
+    "@simple-dom/interface" "^1.4.0"
+
 "@glimmer/interfaces@^0.54.2":
   version "0.54.2"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.54.2.tgz#d7735869050ca7e1731424aa64ae37b1cb853091"
   integrity sha512-Gqvr6Eh4Xy7lF14GZi6RbnVeA7gDj2pXMJtdh68TFL2u/VqfhTXy4+IFRvUh4bpJj+1YayNFupuJSn0oVrEDGQ==
-  dependencies:
-    "@simple-dom/interface" "^1.4.0"
-
-"@glimmer/interfaces@^0.56.0":
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.56.0.tgz#88fbbfb31076c39de4b87af12151c2f6b2aec75c"
-  integrity sha512-MXWkPg8/EECK0pkjCmDb6BTpCBQT83S8R5qKHSZ6yPJmd6AWUunfT/CoHM6faH5yHW4ya7ckM1ZfrHnU5eda4Q==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
@@ -1047,15 +1047,15 @@
     handlebars "^4.7.4"
     simple-html-tokenizer "^0.5.9"
 
-"@glimmer/syntax@^0.56.0":
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.56.0.tgz#9f7673bdf94637e8652a942a42c96d67fcce9523"
-  integrity sha512-bh0pYOIRKABm6hy2B0QDL1+iJHafDj+lwaLQGtuoDBd2rfbJdmeOfGuKPjU51gQ7tllt/6lOdkQQG4yuO2CNRQ==
+"@glimmer/syntax@^0.62.3":
+  version "0.62.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.62.3.tgz#8c4abd245a54e8cc084a47ab4a65c33194256fda"
+  integrity sha512-PU4PpMg9UOeYFTODkHN9K6As74lm16XGEQAQbd59oAbvGRu5OAIWFtSU4sMexpKOXu6iJacFO5udX7gVTACRQQ==
   dependencies:
-    "@glimmer/interfaces" "^0.56.0"
-    "@glimmer/util" "^0.56.0"
-    handlebars "^4.7.4"
-    simple-html-tokenizer "^0.5.9"
+    "@glimmer/interfaces" "0.62.3"
+    "@glimmer/util" "0.62.3"
+    "@handlebars/parser" "^1.1.0"
+    simple-html-tokenizer "^0.5.10"
 
 "@glimmer/tracking@^1.0.0":
   version "1.0.1"
@@ -1064,6 +1064,15 @@
   dependencies:
     "@glimmer/env" "^0.1.7"
     "@glimmer/validator" "^0.44.0"
+
+"@glimmer/util@0.62.3":
+  version "0.62.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.62.3.tgz#d6fc5d64e5e97cbec02b5fcf8a8c78c7f67dc6f5"
+  integrity sha512-HImkS2UJuZYPxyjXPFL9PS659kwjNcRIr5hnUo1PzrPfyZxXwWys2+vTxIv34tI1xkgkQmB1pB0S8pCdNrJY5w==
+  dependencies:
+    "@glimmer/env" "0.1.7"
+    "@glimmer/interfaces" "0.62.3"
+    "@simple-dom/interface" "^1.4.0"
 
 "@glimmer/util@^0.44.0":
   version "0.44.0"
@@ -1079,19 +1088,15 @@
     "@glimmer/interfaces" "^0.54.2"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/util@^0.56.0":
-  version "0.56.0"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.56.0.tgz#8bce5676c8ac9b9389a736505a57925f7b55d1af"
-  integrity sha512-3TmGZIe5jTtHbjjTV7mwr71M47c+Y1njm3QrJ8Jq4KzD2udryiQkj44Aki+RFlpjZxBRTWWHHInurb6niPr/cg==
-  dependencies:
-    "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "^0.56.0"
-    "@simple-dom/interface" "^1.4.0"
-
 "@glimmer/validator@^0.44.0":
   version "0.44.0"
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
+
+"@handlebars/parser@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
+  integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -10796,6 +10801,11 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0, silent-error@^1.1
   integrity sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==
   dependencies:
     debug "^2.2.0"
+
+simple-html-tokenizer@^0.5.10:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.10.tgz#0843e4f00c9677f1c81e3dfeefcee0a4aca8e5d0"
+  integrity sha512-1DHMUmvUOGuUZ9/+cX/+hOhWhRD5dEw6lodn8WuV+T+cQ31hhBcCu1dcDsNotowi4mMaNhrLyKoS+DtB81HdDA==
 
 simple-html-tokenizer@^0.5.9:
   version "0.5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,10 +1776,17 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
-ast-types@0.13.3, ast-types@^0.13.2:
+ast-types@0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.3.tgz#50da3f28d17bdbc7969a3a2d83a0e4a72ae755a7"
   integrity sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==
+
+ast-types@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
+  integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==
+  dependencies:
+    tslib "^2.0.1"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -11678,6 +11685,11 @@ tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,10 +258,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.3.4", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.7.0":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
-  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
+"@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.12.3", "@babel/parser@^7.3.4", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
+  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.10.5"


### PR DESCRIPTION
This updates the dependencies used for parsing js/ts/hbs files to their latest versions:

* `@glimmer/syntax@0.62.3`
* `@babel/parser@7.12.3`
* `ast-types@0.14.2`