### PR TITLE
Allow to specify a full input path for l10n:convert

### DIFF
--- a/lib/commands/convert.js
+++ b/lib/commands/convert.js
@@ -55,6 +55,13 @@ module.exports = Object.assign(BaseCommand, {
       description: 'Directory of PO file to convert',
     },
     {
+      name: 'convert-from-file',
+      type: String,
+      aliases: ['f'],
+      description:
+        'Optional full path to file to convert. Takes precedence over convert-from & language.',
+    },
+    {
       name: 'convert-to',
       type: String,
       aliases: ['o'],
@@ -95,7 +102,9 @@ module.exports = Object.assign(BaseCommand, {
    */
   start(options) {
     let fullPath = options.convertTo;
-    let poFile = `${options.convertFrom}/${options.language}.po`;
+    let poFile =
+      options.convertFromFile ||
+      `${options.convertFrom}/${options.language}.po`;
     let jsonFile = `${fullPath}/${options.language}.json`;
 
     if (!this.fileExists_(poFile)) {

--- a/node-tests/acceptance/commands/convert-test.js
+++ b/node-tests/acceptance/commands/convert-test.js
@@ -102,6 +102,28 @@ describe('convert command', function () {
     });
   });
 
+  it('it allows to specify a full input file path', async function () {
+    let options = getOptions({
+      convertFromFile: `${tmpDir}/custom.po`,
+    });
+
+    // First put the example en.po in the output folder
+    fs.copyFileSync(
+      './node-tests/fixtures/convert/en.po',
+      options.convertFromFile
+    );
+
+    let cmd = createCommand();
+    await cmd.run(options);
+
+    let actualFileContent = readJSONFromFile('./tmp/ember-l10n-tests/en.json');
+    let expectedFileContent = readJSONFromFile(
+      './node-tests/fixtures/convert/expected.json'
+    );
+
+    expect(actualFileContent).to.deep.equals(expectedFileContent);
+  });
+
   it('it appends a semicolon to the plural forms if it is missing', async function () {
     let options = getOptions({});
 


### PR DESCRIPTION
Currently, we always expect the translated files to be e.g. `de.po` in a translations folder. However, some tools put translated files somewhere else, e.g. in a `de/messages.po` file or similar. 

With this PR, you can optionally provide an argument:

```bash
ember l10n:convert -convert-from-file translations/de/messages.po -l de
```

To convert from any file path.